### PR TITLE
refactor: simplify job names and convert kics to reusable workflow

### DIFF
--- a/.github/workflows/ha-integration.yml
+++ b/.github/workflows/ha-integration.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   test-python:
-    name: "Python Tests & Coverage (80%+)"
+    name: pytest
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -34,7 +34,7 @@ jobs:
         run: pytest --cov=custom_components/$COMPONENT_NAME --cov-fail-under=80 tests/ -v
 
   lint-python:
-    name: "Code Quality - Python (ruff)"
+    name: ruff
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/kics.yml
+++ b/.github/workflows/kics.yml
@@ -1,15 +1,11 @@
 name: KICS Scan
 
 on:
-  push:
-    branches:
-      - main
-  pull_request:
-  workflow_dispatch:
+  workflow_call:
 
 jobs:
   kics:
-    name: Kics Scan
+    name: kics
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/lint-markdown.yml
+++ b/.github/workflows/lint-markdown.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   lint-markdown:
-    name: "Code Quality - Markdown (markdownlint)"
+    name: markdownlint
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary

- Remove verbose display names from reusable workflow jobs — job IDs are now used as status check names (`pytest`, `ruff`, `markdownlint`, `kics`)
- Convert `kics.yml` from standalone workflow to reusable (`workflow_call`) so it can be called from consumer repos via `validation.yml`

## Resulting check names

```
PR Validation / python / pytest
PR Validation / python / ruff
PR Validation / markdown / markdownlint
PR Validation / kics / kics
```