### PR TITLE
feat: add shellcheck and shfmt linters to lint.yml via reviewdog

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -90,6 +90,7 @@ jobs:
         mirror.gcr.io:443
         pkg-containers.githubusercontent.com:443
         production.cloudflare.docker.com:443
+        raw.githubusercontent.com:443
         registry-1.docker.io:443
     steps:
       - name: Harden Runner
@@ -221,6 +222,7 @@ jobs:
         mirror.gcr.io:443
         pkg-containers.githubusercontent.com:443
         production.cloudflare.docker.com:443
+        raw.githubusercontent.com:443
         registry-1.docker.io:443
     steps:
       - name: Harden Runner
@@ -271,6 +273,7 @@ jobs:
         mirror.gcr.io:443
         pkg-containers.githubusercontent.com:443
         production.cloudflare.docker.com:443
+        raw.githubusercontent.com:443
         registry-1.docker.io:443
     steps:
       - name: Harden Runner

--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -84,6 +84,7 @@ jobs:
         api.github.com:443
         auth.docker.io:443
         check.trivy.dev:443
+        get.anchore.io:443
         get.trivy.dev:443
         ghcr.io:443
         github.com:443
@@ -92,6 +93,7 @@ jobs:
         production.cloudflare.docker.com:443
         raw.githubusercontent.com:443
         registry-1.docker.io:443
+        release-assets.githubusercontent.com:443
     steps:
       - name: Harden Runner
         if: ${{ inputs.enable_harden_runner }}
@@ -216,6 +218,7 @@ jobs:
         api.github.com:443
         auth.docker.io:443
         check.trivy.dev:443
+        get.anchore.io:443
         get.trivy.dev:443
         ghcr.io:443
         github.com:443
@@ -224,6 +227,7 @@ jobs:
         production.cloudflare.docker.com:443
         raw.githubusercontent.com:443
         registry-1.docker.io:443
+        release-assets.githubusercontent.com:443
     steps:
       - name: Harden Runner
         if: ${{ inputs.enable_harden_runner }}
@@ -267,6 +271,7 @@ jobs:
         api.github.com:443
         auth.docker.io:443
         check.trivy.dev:443
+        get.anchore.io:443
         get.trivy.dev:443
         ghcr.io:443
         github.com:443
@@ -275,6 +280,7 @@ jobs:
         production.cloudflare.docker.com:443
         raw.githubusercontent.com:443
         registry-1.docker.io:443
+        release-assets.githubusercontent.com:443
     steps:
       - name: Harden Runner
         if: ${{ inputs.enable_harden_runner }}

--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -87,6 +87,7 @@ jobs:
       #   get.trivy.dev:443 — Trivy install script (trivy-action)
       #   ghcr.io:443 — GitHub Container Registry (push/pull images)
       #   github.com:443 — git clone, actions checkout
+      #   grype.anchore.io:443 — Grype DB listing endpoint (scan-action)
       #   mirror.gcr.io:443 — GCR mirror (Docker daemon)
       #   pkg-containers.githubusercontent.com:443 — GHCR storage backend
       #   production.cloudflare.docker.com:443 — Docker Hub CDN (setup-qemu-action)
@@ -102,6 +103,7 @@ jobs:
         get.trivy.dev:443
         ghcr.io:443
         github.com:443
+        grype.anchore.io:443
         mirror.gcr.io:443
         pkg-containers.githubusercontent.com:443
         production.cloudflare.docker.com:443
@@ -237,6 +239,7 @@ jobs:
         get.trivy.dev:443
         ghcr.io:443
         github.com:443
+        grype.anchore.io:443
         mirror.gcr.io:443
         pkg-containers.githubusercontent.com:443
         production.cloudflare.docker.com:443
@@ -291,6 +294,7 @@ jobs:
         get.trivy.dev:443
         ghcr.io:443
         github.com:443
+        grype.anchore.io:443
         mirror.gcr.io:443
         pkg-containers.githubusercontent.com:443
         production.cloudflare.docker.com:443

--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -78,7 +78,21 @@ jobs:
       packages: write
       security-events: write
     env:
-      # Built-in defaults — always applied, merged with inputs.harden_runner_allowed_endpoints
+      # Built-in harden-runner allowed endpoints:
+      #   agent.api.stepsecurity.io:443 — harden-runner agent
+      #   api.github.com:443 — GitHub API (actions runtime, SARIF upload, staging cleanup)
+      #   auth.docker.io:443 — Docker Hub auth (setup-qemu-action)
+      #   check.trivy.dev:443 — Trivy version check (trivy-action)
+      #   get.anchore.io:443 — Grype DB download (scan-action)
+      #   get.trivy.dev:443 — Trivy install script (trivy-action)
+      #   ghcr.io:443 — GitHub Container Registry (push/pull images)
+      #   github.com:443 — git clone, actions checkout
+      #   mirror.gcr.io:443 — GCR mirror (Docker daemon)
+      #   pkg-containers.githubusercontent.com:443 — GHCR storage backend
+      #   production.cloudflare.docker.com:443 — Docker Hub CDN (setup-qemu-action)
+      #   raw.githubusercontent.com:443 — GitHub raw content (grype DB metadata)
+      #   registry-1.docker.io:443 — Docker Hub registry (setup-qemu-action pulls tonistiigi/binfmt)
+      #   release-assets.githubusercontent.com:443 — GitHub release downloads (trivy, grype binaries)
       _HARDEN_DEFAULTS: >-
         agent.api.stepsecurity.io:443
         api.github.com:443
@@ -213,6 +227,7 @@ jobs:
       contents: read
       security-events: write
     env:
+      # Built-in endpoints — see first job above
       _HARDEN_DEFAULTS: >-
         agent.api.stepsecurity.io:443
         api.github.com:443
@@ -266,6 +281,7 @@ jobs:
       contents: read
       security-events: write
     env:
+      # Built-in endpoints — see first job above
       _HARDEN_DEFAULTS: >-
         agent.api.stepsecurity.io:443
         api.github.com:443

--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -5,14 +5,13 @@ name: Docker CI
 #
 # Ordre garanti quand enable_build=true :
 #   1. Build → push staging tag (ex: :scan-{run_id})
-#   2. Scan Trivy et/ou grype sur le staging tag
+#   2. Scan Trivy sur le staging tag
 #   3. Publish final (bake avec les tags originaux du bake file, depuis le cache)
-# Si un scan échoue, le job échoue → le publish final ne s'exécute pas.
+# Si le scan échoue, le job échoue → le publish final ne s'exécute pas.
 #
-# Mode scan-only (enable_build=false) : jobs trivy-scan et grype-scan indépendants,
-# tournent sur une image existante dans le registre (image_name ou défaut).
+# Mode scan-only (enable_build=false) : job trivy-scan indépendant,
+# tourne sur une image existante dans le registre (image_name ou défaut).
 #
-# Enable_trivy et enable_grype sont indépendants.
 # image_name : si non fourni, utilise {registry}/{github.repository} par défaut.
 
 on:
@@ -20,10 +19,6 @@ on:
     inputs:
       enable_build:
         description: "Docker build & push via bake"
-        type: boolean
-        default: false
-      enable_grype:
-        description: "CVE scan via grype (Anchore/Cisco)"
         type: boolean
         default: false
       enable_harden_runner:
@@ -34,10 +29,6 @@ on:
         description: "CVE scan via Trivy (aquasecurity)"
         type: boolean
         default: false
-      grype_severity_cutoff:
-        description: "Grype minimum severity to fail build (negligible, low, medium, high, critical)"
-        type: string
-        default: "negligible"
       harden_runner_allowed_endpoints:
         description: "Extra endpoints to allow (merged with built-in defaults, space-separated)"
         type: string
@@ -83,27 +74,23 @@ jobs:
       #   api.github.com:443 — GitHub API (actions runtime, SARIF upload, staging cleanup)
       #   auth.docker.io:443 — Docker Hub auth (setup-qemu-action)
       #   check.trivy.dev:443 — Trivy version check (trivy-action)
-      #   get.anchore.io:443 — Grype DB download (scan-action)
       #   get.trivy.dev:443 — Trivy install script (trivy-action)
       #   ghcr.io:443 — GitHub Container Registry (push/pull images)
       #   github.com:443 — git clone, actions checkout
-      #   grype.anchore.io:443 — Grype DB listing endpoint (scan-action)
       #   mirror.gcr.io:443 — GCR mirror (Docker daemon)
       #   pkg-containers.githubusercontent.com:443 — GHCR storage backend
       #   production.cloudflare.docker.com:443 — Docker Hub CDN (setup-qemu-action)
-      #   raw.githubusercontent.com:443 — GitHub raw content (grype DB metadata)
+      #   raw.githubusercontent.com:443 — GitHub raw content
       #   registry-1.docker.io:443 — Docker Hub registry (setup-qemu-action pulls tonistiigi/binfmt)
-      #   release-assets.githubusercontent.com:443 — GitHub release downloads (trivy, grype binaries)
+      #   release-assets.githubusercontent.com:443 — GitHub release downloads (trivy binaries)
       _HARDEN_DEFAULTS: >-
         agent.api.stepsecurity.io:443
         api.github.com:443
         auth.docker.io:443
         check.trivy.dev:443
-        get.anchore.io:443
         get.trivy.dev:443
         ghcr.io:443
         github.com:443
-        grype.anchore.io:443
         mirror.gcr.io:443
         pkg-containers.githubusercontent.com:443
         production.cloudflare.docker.com:443
@@ -129,7 +116,7 @@ jobs:
       # ── Phase 1 : build staging tag (pour le scan) ─────────────────────────
       - name: Set staging tag
         id: staging
-        if: ${{ inputs.enable_trivy || inputs.enable_grype }}
+        if: ${{ inputs.enable_trivy }}
         env:
           REGISTRY: ${{ inputs.registry }}
           REPOSITORY: ${{ github.repository }}
@@ -137,7 +124,7 @@ jobs:
         run: echo "tag=${REGISTRY}/${REPOSITORY}:scan-${RUN_ID}" >> "$GITHUB_OUTPUT"
 
       - name: Build staging image
-        if: ${{ inputs.enable_trivy || inputs.enable_grype }}
+        if: ${{ inputs.enable_trivy }}
         uses: docker/bake-action@82490499d2e5613fcead7e128237ef0b0ea210f7 # v7.0.0
         with:
           push: true
@@ -170,22 +157,6 @@ jobs:
           sarif_file: trivy-results.sarif
           category: trivy-container
 
-      - name: Grype scan
-        if: ${{ inputs.enable_grype }}
-        id: grype
-        uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # v7.4.0
-        with:
-          image: ${{ steps.staging.outputs.tag }}
-          fail-build: true
-          severity-cutoff: ${{ inputs.grype_severity_cutoff }}
-
-      - name: Upload Grype SARIF
-        if: ${{ always() && inputs.enable_grype }}
-        uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
-        with:
-          sarif_file: ${{ steps.grype.outputs.sarif }}
-          category: grype-container
-
       # ── Phase 3 : publish final ────────────────────────────────────────────
       - name: Publish final image
         if: ${{ github.event_name != 'pull_request' }}
@@ -195,7 +166,7 @@ jobs:
 
       # ── Nettoyage staging tag ──────────────────────────────────────────────
       - name: Delete staging tag
-        if: ${{ always() && (inputs.enable_trivy || inputs.enable_grype) }}
+        if: ${{ always() && inputs.enable_trivy }}
         continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -235,11 +206,9 @@ jobs:
         api.github.com:443
         auth.docker.io:443
         check.trivy.dev:443
-        get.anchore.io:443
         get.trivy.dev:443
         ghcr.io:443
         github.com:443
-        grype.anchore.io:443
         mirror.gcr.io:443
         pkg-containers.githubusercontent.com:443
         production.cloudflare.docker.com:443
@@ -275,50 +244,3 @@ jobs:
         with:
           sarif_file: trivy-results.sarif
           category: trivy-container
-
-  grype-scan:
-    if: ${{ inputs.enable_grype && !inputs.enable_build }}
-    name: Container Scan (grype)
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      security-events: write
-    env:
-      # Built-in endpoints — see first job above
-      _HARDEN_DEFAULTS: >-
-        agent.api.stepsecurity.io:443
-        api.github.com:443
-        auth.docker.io:443
-        check.trivy.dev:443
-        get.anchore.io:443
-        get.trivy.dev:443
-        ghcr.io:443
-        github.com:443
-        grype.anchore.io:443
-        mirror.gcr.io:443
-        pkg-containers.githubusercontent.com:443
-        production.cloudflare.docker.com:443
-        raw.githubusercontent.com:443
-        registry-1.docker.io:443
-        release-assets.githubusercontent.com:443
-    steps:
-      - name: Harden Runner
-        if: ${{ inputs.enable_harden_runner }}
-        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
-        with:
-          egress-policy: ${{ inputs.harden_runner_egress_policy }}
-          allowed-endpoints: ${{ env._HARDEN_DEFAULTS }} ${{ inputs.harden_runner_allowed_endpoints }}
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Grype scan
-        id: grype
-        uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # v7.4.0
-        with:
-          image: "${{ inputs.image_name != '' && inputs.image_name || format('{0}/{1}', inputs.registry, github.repository) }}"
-          fail-build: true
-          severity-cutoff: ${{ inputs.grype_severity_cutoff }}
-      - name: Upload Grype SARIF
-        if: always()
-        uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
-        with:
-          sarif_file: ${{ steps.grype.outputs.sarif }}
-          category: grype-container

--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -18,54 +18,54 @@ name: Docker CI
 on:
   workflow_call:
     inputs:
-      enable_harden_runner:
-        description: "Runtime security via StepSecurity harden-runner"
-        type: boolean
-        default: true
-      harden_runner_egress_policy:
-        description: "Harden-runner egress policy: audit (observe) or block (enforce allowlist)"
-        type: string
-        default: "audit"
-      harden_runner_allowed_endpoints:
-        description: "Extra endpoints to allow (merged with built-in defaults, space-separated)"
-        type: string
-        default: ""
       enable_build:
         description: "Docker build & push via bake"
-        type: boolean
-        default: false
-      enable_trivy:
-        description: "CVE scan via Trivy (aquasecurity)"
         type: boolean
         default: false
       enable_grype:
         description: "CVE scan via grype (Anchore/Cisco)"
         type: boolean
         default: false
-      registry:
-        description: "Target Docker registry"
-        type: string
-        default: "ghcr.io"
-      image_name:
-        description: "Image name (e.g., owner/image) — defaults to {registry}/{github.repository}"
-        type: string
-        default: ""
-      trivy_severity:
-        description: "Trivy severity levels (empty = all)"
-        type: string
-        default: ""
+      enable_harden_runner:
+        description: "Runtime security via StepSecurity harden-runner"
+        type: boolean
+        default: true
+      enable_trivy:
+        description: "CVE scan via Trivy (aquasecurity)"
+        type: boolean
+        default: false
       grype_severity_cutoff:
         description: "Grype minimum severity to fail build (negligible, low, medium, high, critical)"
         type: string
         default: "negligible"
+      harden_runner_allowed_endpoints:
+        description: "Extra endpoints to allow (merged with built-in defaults, space-separated)"
+        type: string
+        default: ""
+      harden_runner_egress_policy:
+        description: "Harden-runner egress policy: audit (observe) or block (enforce allowlist)"
+        type: string
+        default: "audit"
+      image_name:
+        description: "Image name (e.g., owner/image) — defaults to {registry}/{github.repository}"
+        type: string
+        default: ""
+      registry:
+        description: "Target Docker registry"
+        type: string
+        default: "ghcr.io"
+      trivy_severity:
+        description: "Trivy severity levels (empty = all)"
+        type: string
+        default: ""
     secrets:
-      registry_username:
-        description: "Docker registry username (optional — uses GITHUB_TOKEN for ghcr.io)"
-        required: false
       registry_password:
         description: "Docker registry password (optional — uses GITHUB_TOKEN for ghcr.io)"
         required: false
 
+      registry_username:
+        description: "Docker registry username (optional — uses GITHUB_TOKEN for ghcr.io)"
+        required: false
 permissions: {}
 
 jobs:

--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -3,24 +3,15 @@ name: Docker CI
 # Reusable workflow — Docker Build & Container Scanning
 # Usage: uses: trowaflo/github-actions/.github/workflows/ci-docker.yml@<sha>
 #
-# Ordre garanti quand enable_build=true :
+# Ordre garanti :
 #   1. Build → push staging tag (ex: :scan-{run_id})
 #   2. Scan Trivy sur le staging tag
 #   3. Publish final (bake avec les tags originaux du bake file, depuis le cache)
 # Si le scan échoue, le job échoue → le publish final ne s'exécute pas.
-#
-# Mode scan-only (enable_build=false) : job trivy-scan indépendant,
-# tourne sur une image existante dans le registre (image_name ou défaut).
-#
-# image_name : si non fourni, utilise {registry}/{github.repository} par défaut.
 
 on:
   workflow_call:
     inputs:
-      enable_build:
-        description: "Docker build & push via bake"
-        type: boolean
-        default: false
       enable_harden_runner:
         description: "Runtime security via StepSecurity harden-runner"
         type: boolean
@@ -37,10 +28,6 @@ on:
         description: "Harden-runner egress policy: audit (observe) or block (enforce allowlist)"
         type: string
         default: "audit"
-      image_name:
-        description: "Image name (e.g., owner/image) — defaults to {registry}/{github.repository}"
-        type: string
-        default: ""
       registry:
         description: "Target Docker registry"
         type: string
@@ -61,7 +48,6 @@ permissions: {}
 
 jobs:
   docker:
-    if: ${{ inputs.enable_build }}
     name: Docker Build → Scan → Publish
     runs-on: ubuntu-latest
     permissions:
@@ -189,58 +175,3 @@ jobs:
           else
             echo "Staging version not found — will expire per ghcr.io retention policy (90 days)"
           fi
-
-  # ── Mode scan-only (enable_build=false) ────────────────────────────────────
-
-  trivy-scan:
-    if: ${{ inputs.enable_trivy && !inputs.enable_build }}
-    name: Container Scan (Trivy)
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      security-events: write
-    env:
-      # Built-in endpoints — see first job above
-      _HARDEN_DEFAULTS: >-
-        agent.api.stepsecurity.io:443
-        api.github.com:443
-        auth.docker.io:443
-        check.trivy.dev:443
-        get.trivy.dev:443
-        ghcr.io:443
-        github.com:443
-        mirror.gcr.io:443
-        pkg-containers.githubusercontent.com:443
-        production.cloudflare.docker.com:443
-        raw.githubusercontent.com:443
-        registry-1.docker.io:443
-        release-assets.githubusercontent.com:443
-    steps:
-      - name: Harden Runner
-        if: ${{ inputs.enable_harden_runner }}
-        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
-        with:
-          egress-policy: ${{ inputs.harden_runner_egress_policy }}
-          allowed-endpoints: ${{ env._HARDEN_DEFAULTS }} ${{ inputs.harden_runner_allowed_endpoints }}
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Trivy scan (table)
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
-        with:
-          image-ref: "${{ inputs.image_name != '' && inputs.image_name || format('{0}/{1}', inputs.registry, github.repository) }}"
-          format: table
-          severity: ${{ inputs.trivy_severity }}
-          exit-code: "1"
-      - name: Trivy scan (SARIF)
-        if: always()
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
-        with:
-          image-ref: "${{ inputs.image_name != '' && inputs.image_name || format('{0}/{1}', inputs.registry, github.repository) }}"
-          format: sarif
-          output: trivy-results.sarif
-          severity: ${{ inputs.trivy_severity }}
-      - name: Upload Trivy SARIF
-        if: always()
-        uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
-        with:
-          sarif_file: trivy-results.sarif
-          category: trivy-container

--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -81,12 +81,16 @@ jobs:
       # Built-in defaults — always applied, merged with inputs.harden_runner_allowed_endpoints
       _HARDEN_DEFAULTS: >-
         agent.api.stepsecurity.io:443
-        github.com:443
         api.github.com:443
-        ghcr.io:443
-        pkg-containers.githubusercontent.com:443
+        auth.docker.io:443
+        check.trivy.dev:443
         get.trivy.dev:443
+        ghcr.io:443
+        github.com:443
         mirror.gcr.io:443
+        pkg-containers.githubusercontent.com:443
+        production.cloudflare.docker.com:443
+        registry-1.docker.io:443
     steps:
       - name: Harden Runner
         if: ${{ inputs.enable_harden_runner }}
@@ -208,12 +212,16 @@ jobs:
     env:
       _HARDEN_DEFAULTS: >-
         agent.api.stepsecurity.io:443
-        github.com:443
         api.github.com:443
-        ghcr.io:443
-        pkg-containers.githubusercontent.com:443
+        auth.docker.io:443
+        check.trivy.dev:443
         get.trivy.dev:443
+        ghcr.io:443
+        github.com:443
         mirror.gcr.io:443
+        pkg-containers.githubusercontent.com:443
+        production.cloudflare.docker.com:443
+        registry-1.docker.io:443
     steps:
       - name: Harden Runner
         if: ${{ inputs.enable_harden_runner }}
@@ -254,12 +262,16 @@ jobs:
     env:
       _HARDEN_DEFAULTS: >-
         agent.api.stepsecurity.io:443
-        github.com:443
         api.github.com:443
-        ghcr.io:443
-        pkg-containers.githubusercontent.com:443
+        auth.docker.io:443
+        check.trivy.dev:443
         get.trivy.dev:443
+        ghcr.io:443
+        github.com:443
         mirror.gcr.io:443
+        pkg-containers.githubusercontent.com:443
+        production.cloudflare.docker.com:443
+        registry-1.docker.io:443
     steps:
       - name: Harden Runner
         if: ${{ inputs.enable_harden_runner }}

--- a/.github/workflows/ci-ha.yml
+++ b/.github/workflows/ci-ha.yml
@@ -11,35 +11,6 @@ name: Home Assistant CI
 on:
   workflow_call:
     inputs:
-      enable_harden_runner:
-        description: "Runtime security via StepSecurity harden-runner"
-        type: boolean
-        default: true
-      harden_runner_egress_policy:
-        description: "Harden-runner egress policy: audit (observe) or block (enforce allowlist)"
-        type: string
-        default: "audit"
-      harden_runner_allowed_endpoints:
-        description: "Extra endpoints to allow (merged with built-in defaults, space-separated)"
-        type: string
-        # HA actions pull Docker images from ghcr.io
-        default: ""
-      enable_hacs:
-        description: "HACS validation"
-        type: boolean
-        default: false
-      enable_hassfest:
-        description: "hassfest validation"
-        type: boolean
-        default: false
-      enable_config_check:
-        description: "HA config check"
-        type: boolean
-        default: false
-      ha_version:
-        description: "Home Assistant version — required if enable_config_check (e.g. 2026.3.4, stable, beta)"
-        type: string
-        default: ""
       config_check_secrets:
         description: "Path to a secrets file for config check (e.g. secrets.fake.yaml)"
         type: string
@@ -48,11 +19,40 @@ on:
         description: "Shell commands to run before config check (e.g. install custom components)"
         type: string
         default: ""
+      enable_config_check:
+        description: "HA config check"
+        type: boolean
+        default: false
+      enable_hacs:
+        description: "HACS validation"
+        type: boolean
+        default: false
+      enable_harden_runner:
+        description: "Runtime security via StepSecurity harden-runner"
+        type: boolean
+        default: true
+      enable_hassfest:
+        description: "hassfest validation"
+        type: boolean
+        default: false
+      ha_version:
+        description: "Home Assistant version — required if enable_config_check (e.g. 2026.3.4, stable, beta)"
+        type: string
+        default: ""
       hacs_ignore:
         description: "Space-separated HACS checks to skip (e.g. 'brands topics')"
         type: string
         default: ""
 
+      harden_runner_allowed_endpoints:
+        description: "Extra endpoints to allow (merged with built-in defaults, space-separated)"
+        type: string
+        # HA actions pull Docker images from ghcr.io
+        default: ""
+      harden_runner_egress_policy:
+        description: "Harden-runner egress policy: audit (observe) or block (enforce allowlist)"
+        type: string
+        default: "audit"
 permissions: {}
 
 jobs:

--- a/.github/workflows/ci-ha.yml
+++ b/.github/workflows/ci-ha.yml
@@ -63,7 +63,14 @@ jobs:
     permissions:
       contents: read
     env:
-      # Built-in defaults — always applied, merged with inputs.harden_runner_allowed_endpoints
+      # Built-in harden-runner allowed endpoints:
+      #   agent.api.stepsecurity.io:443 — harden-runner agent
+      #   api.github.com:443 — GitHub API (actions runtime)
+      #   brands.home-assistant.io:443 — HA brands validation (HACS)
+      #   ghcr.io:443 — HA container images (hassfest, config-check)
+      #   github.com:443 — git clone, actions checkout
+      #   pkg-containers.githubusercontent.com:443 — GHCR storage backend
+      #   raw.githubusercontent.com:443 — GitHub raw content (HACS validation)
       _HARDEN_DEFAULTS: >-
         agent.api.stepsecurity.io:443
         github.com:443
@@ -92,7 +99,7 @@ jobs:
     permissions:
       contents: read
     env:
-      # Built-in defaults — always applied, merged with inputs.harden_runner_allowed_endpoints
+      # Built-in endpoints — see first job above
       _HARDEN_DEFAULTS: >-
         agent.api.stepsecurity.io:443
         github.com:443
@@ -118,7 +125,7 @@ jobs:
     permissions:
       contents: read
     env:
-      # Built-in defaults — always applied, merged with inputs.harden_runner_allowed_endpoints
+      # Built-in endpoints — see first job above
       _HARDEN_DEFAULTS: >-
         agent.api.stepsecurity.io:443
         github.com:443

--- a/.github/workflows/ci-helm-cleanup.yml
+++ b/.github/workflows/ci-helm-cleanup.yml
@@ -36,6 +36,11 @@ jobs:
       contents: write
       pull-requests: write
     env:
+      # Built-in harden-runner allowed endpoints:
+      #   agent.api.stepsecurity.io:443 — harden-runner agent
+      #   api.github.com:443 — GitHub API (PR chart cleanup via github-script)
+      #   get.helm.sh:443 — Helm binary (azure/setup-helm)
+      #   github.com:443 — git clone, actions checkout
       _HARDEN_DEFAULTS: >-
         agent.api.stepsecurity.io:443
         github.com:443

--- a/.github/workflows/ci-helm-cleanup.yml
+++ b/.github/workflows/ci-helm-cleanup.yml
@@ -12,14 +12,14 @@ on:
         description: "Runtime security via StepSecurity harden-runner"
         type: boolean
         default: true
-      harden_runner_egress_policy:
-        description: "Harden-runner egress policy: audit (observe) or block (enforce allowlist)"
-        type: string
-        default: "audit"
       harden_runner_allowed_endpoints:
         description: "Extra endpoints to allow (merged with built-in defaults, space-separated)"
         type: string
         default: ""
+      harden_runner_egress_policy:
+        description: "Harden-runner egress policy: audit (observe) or block (enforce allowlist)"
+        type: string
+        default: "audit"
       skip_event_check:
         description: "Skip event.action == closed check (for testing only)"
         type: boolean

--- a/.github/workflows/ci-helm.yml
+++ b/.github/workflows/ci-helm.yml
@@ -9,29 +9,15 @@ name: Helm CI
 on:
   workflow_call:
     inputs:
-      enable_harden_runner:
-        description: "Runtime security via StepSecurity harden-runner"
-        type: boolean
-        default: true
-      harden_runner_egress_policy:
-        description: "Harden-runner egress policy: audit (observe) or block (enforce allowlist)"
+      bump_skip_actors:
+        description: "Comma-separated actors to skip for version bumping (e.g., 'renovate[bot]')"
         type: string
-        default: "audit"
-      harden_runner_allowed_endpoints:
-        description: >-
-          Extra endpoints to allow (merged with built-in defaults, space-separated).
-          Note: enable_pr_charts adds Helm repo endpoints dynamically from Chart.yaml
-          dependencies — add those hosts here if charts reference external repositories.
+        default: "renovate[bot]"
+
+      charts_dir:
+        description: "Root directory for Helm charts"
         type: string
-        default: ""
-      enable_lint:
-        description: "Lint charts with chart-testing (ct lint)"
-        type: boolean
-        default: false
-      enable_unittest:
-        description: "Helm unit tests with helm-unittest (matrix per chart)"
-        type: boolean
-        default: false
+        default: "charts"
       enable_bump:
         description: "Auto-bump chart versions on PR using conventional commits (major/minor/patch)"
         type: boolean
@@ -44,19 +30,33 @@ on:
         description: "Validate documentation is up-to-date (dry-run, fails if outdated)"
         type: boolean
         default: false
+      enable_harden_runner:
+        description: "Runtime security via StepSecurity harden-runner"
+        type: boolean
+        default: true
+      enable_lint:
+        description: "Lint charts with chart-testing (ct lint)"
+        type: boolean
+        default: false
       enable_pr_charts:
         description: "Package modified charts on PR and publish to pr-charts branch"
         type: boolean
         default: false
-      charts_dir:
-        description: "Root directory for Helm charts"
+      enable_unittest:
+        description: "Helm unit tests with helm-unittest (matrix per chart)"
+        type: boolean
+        default: false
+      harden_runner_allowed_endpoints:
+        description: >-
+          Extra endpoints to allow (merged with built-in defaults, space-separated).
+          Note: enable_pr_charts adds Helm repo endpoints dynamically from Chart.yaml
+          dependencies — add those hosts here if charts reference external repositories.
         type: string
-        default: "charts"
-      bump_skip_actors:
-        description: "Comma-separated actors to skip for version bumping (e.g., 'renovate[bot]')"
+        default: ""
+      harden_runner_egress_policy:
+        description: "Harden-runner egress policy: audit (observe) or block (enforce allowlist)"
         type: string
-        default: "renovate[bot]"
-
+        default: "audit"
 permissions: {}
 
 jobs:
@@ -71,16 +71,19 @@ jobs:
     env:
       _HARDEN_DEFAULTS: >-
         agent.api.stepsecurity.io:443
-        github.com:443
         api.github.com:443
-        release-assets.githubusercontent.com:443
-        registry.npmjs.org:443
-        objects.githubusercontent.com:443
-        get.helm.sh:443
-        pypi.org:443
         files.pythonhosted.org:443
-        tuf-repo-cdn.sigstore.dev:443
+        get.helm.sh:443
+        get.helm.sh:443
+        ghcr.io:443
+        github.com:443
+        objects.githubusercontent.com:443
+        pypi.org:443
+        quay.io:443
+        registry.npmjs.org:443
         rekor.sigstore.dev:443
+        release-assets.githubusercontent.com:443
+        tuf-repo-cdn.sigstore.dev:443
     steps:
       - name: Harden Runner
         if: ${{ inputs.enable_harden_runner }}

--- a/.github/workflows/ci-helm.yml
+++ b/.github/workflows/ci-helm.yml
@@ -69,6 +69,20 @@ jobs:
     permissions:
       contents: read
     env:
+      # Built-in harden-runner allowed endpoints:
+      #   agent.api.stepsecurity.io:443 — harden-runner agent
+      #   api.github.com:443 — GitHub API (actions runtime, bump push, PR comments)
+      #   files.pythonhosted.org:443 — pip packages (chart-testing-action Python deps)
+      #   get.helm.sh:443 — Helm binary (azure/setup-helm)
+      #   ghcr.io:443 — OCI chart registries
+      #   github.com:443 — git clone, actions checkout
+      #   objects.githubusercontent.com:443 — GitHub release assets (helm-unittest, helm-docs)
+      #   pypi.org:443 — pip index (chart-testing-action)
+      #   quay.io:443 — chart-testing container (quay.io/helmpack/chart-testing)
+      #   registry.npmjs.org:443 — npm packages (setup-node)
+      #   rekor.sigstore.dev:443 — Sigstore transparency log (cosign verification)
+      #   release-assets.githubusercontent.com:443 — GitHub release downloads
+      #   tuf-repo-cdn.sigstore.dev:443 — Sigstore TUF metadata (cosign verification)
       _HARDEN_DEFAULTS: >-
         agent.api.stepsecurity.io:443
         api.github.com:443
@@ -126,6 +140,7 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
       has_charts: ${{ steps.set-matrix.outputs.has_charts }}
     env:
+      # Built-in endpoints — see first job above
       _HARDEN_DEFAULTS: >-
         agent.api.stepsecurity.io:443
         github.com:443
@@ -173,6 +188,7 @@ jobs:
       max-parallel: 5
       matrix: ${{ fromJson(needs.helm-unittest-matrix.outputs.matrix) }}
     env:
+      # Built-in endpoints — see first job above
       _HARDEN_DEFAULTS: >-
         agent.api.stepsecurity.io:443
         github.com:443
@@ -244,6 +260,7 @@ jobs:
     permissions:
       contents: write
     env:
+      # Built-in endpoints — see first job above
       _HARDEN_DEFAULTS: >-
         agent.api.stepsecurity.io:443
         github.com:443
@@ -356,6 +373,7 @@ jobs:
     permissions:
       contents: write
     env:
+      # Built-in endpoints — see first job above
       _HARDEN_DEFAULTS: >-
         agent.api.stepsecurity.io:443
         github.com:443
@@ -418,6 +436,7 @@ jobs:
     permissions:
       contents: read
     env:
+      # Built-in endpoints — see first job above
       _HARDEN_DEFAULTS: >-
         agent.api.stepsecurity.io:443
         github.com:443
@@ -482,6 +501,7 @@ jobs:
       contents: write
       pull-requests: write
     env:
+      # Built-in endpoints — see first job above
       _HARDEN_DEFAULTS: >-
         agent.api.stepsecurity.io:443
         github.com:443

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -65,7 +65,17 @@ jobs:
     permissions:
       contents: read
     env:
-      # Built-in defaults — always applied, merged with inputs.harden_runner_allowed_endpoints
+      # Built-in harden-runner allowed endpoints:
+      #   agent.api.stepsecurity.io:443 — harden-runner agent
+      #   api.github.com:443 — GitHub API (actions runtime)
+      #   cli.codecov.io:443 — Codecov CLI download
+      #   codecov.io:443 — Codecov API
+      #   files.pythonhosted.org:443 — pip packages (pytest, ruff, etc.)
+      #   github.com:443 — git clone, actions checkout
+      #   ingest.codecov.io:443 — Codecov upload endpoint
+      #   keybase.io:443 — Codecov GPG key verification
+      #   pypi.org:443 — pip index
+      #   storage.googleapis.com:443 — Codecov CLI binary storage
       _HARDEN_DEFAULTS: >-
         agent.api.stepsecurity.io:443
         github.com:443
@@ -122,7 +132,7 @@ jobs:
     permissions:
       contents: read
     env:
-      # Built-in defaults — always applied, merged with inputs.harden_runner_allowed_endpoints
+      # Built-in endpoints — see first job above
       _HARDEN_DEFAULTS: >-
         agent.api.stepsecurity.io:443
         github.com:443

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -9,47 +9,47 @@ name: Python CI
 on:
   workflow_call:
     inputs:
+      coverage_path:
+        description: "Coverage path for pytest-cov (e.g., custom_components/my_component)"
+        type: string
+        default: "."
+      coverage_threshold:
+        description: "Minimum coverage threshold (%)"
+        type: string
+        default: "80"
       enable_harden_runner:
         description: "Runtime security via StepSecurity harden-runner"
         type: boolean
         default: true
-      harden_runner_egress_policy:
-        description: "Harden-runner egress policy: audit (observe) or block (enforce allowlist)"
+      enable_lint:
+        description: "Python linting with ruff"
+        type: boolean
+        default: false
+      enable_test:
+        description: "pytest tests + codecov coverage"
+        type: boolean
+        default: false
+      extra_packages:
+        description: "Additional pip packages before tests (e.g., pytest-homeassistant-custom-component==0.13.316)"
         type: string
-        default: "audit"
+        default: ""
       harden_runner_allowed_endpoints:
         description: "Extra endpoints to allow (merged with built-in defaults, space-separated)"
         type: string
         # pip install (pypi + pythonhosted), codecov upload
         default: ""
-      enable_test:
-        description: "pytest tests + codecov coverage"
-        type: boolean
-        default: false
-      enable_lint:
-        description: "Python linting with ruff"
-        type: boolean
-        default: false
+      harden_runner_egress_policy:
+        description: "Harden-runner egress policy: audit (observe) or block (enforce allowlist)"
+        type: string
+        default: "audit"
       python_version:
         description: "Python version"
         type: string
         default: "3.13"
-      coverage_threshold:
-        description: "Minimum coverage threshold (%)"
-        type: string
-        default: "80"
       test_path:
         description: "Test directory"
         type: string
         default: "tests/"
-      coverage_path:
-        description: "Coverage path for pytest-cov (e.g., custom_components/my_component)"
-        type: string
-        default: "."
-      extra_packages:
-        description: "Additional pip packages before tests (e.g., pytest-homeassistant-custom-component==0.13.316)"
-        type: string
-        default: ""
     secrets:
       codecov_token:
         description: "Codecov token (optional — works without for public repos)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
       security-events: write
     with:
       enable_harden_runner: true
+      harden_runner_egress_policy: block
       enable_dependency_review: true
       enable_checkov: true
       enable_trivy: true
@@ -28,6 +29,7 @@ jobs:
       security-events: write
     with:
       enable_harden_runner: true
+      harden_runner_egress_policy: block
       enable_markdown_lint: true
       enable_yamllint: true
       enable_json_lint: true
@@ -40,6 +42,7 @@ jobs:
       contents: read
     with:
       enable_harden_runner: true
+      harden_runner_egress_policy: block
 
   sha-check:
     name: SHA Pinning Check

--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -21,14 +21,14 @@ on:
         description: "Runtime security via StepSecurity harden-runner"
         type: boolean
         default: true
-      harden_runner_egress_policy:
-        description: "Harden-runner egress policy: audit (observe) or block (enforce allowlist)"
-        type: string
-        default: "audit"
       harden_runner_allowed_endpoints:
         description: "Extra endpoints to allow (merged with built-in defaults, space-separated)"
         type: string
         default: ""
+      harden_runner_egress_policy:
+        description: "Harden-runner egress policy: audit (observe) or block (enforce allowlist)"
+        type: string
+        default: "audit"
     secrets:
       claude_code_oauth_token:
         description: "Claude Code OAuth token"

--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -51,7 +51,11 @@ jobs:
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     env:
-      # Built-in defaults — always applied, merged with inputs.harden_runner_allowed_endpoints
+      # Built-in harden-runner allowed endpoints:
+      #   agent.api.stepsecurity.io:443 — harden-runner agent
+      #   api.anthropic.com:443 — Claude API (claude-code-action)
+      #   api.github.com:443 — GitHub API (PR comments, code review)
+      #   github.com:443 — git clone, actions checkout
       _HARDEN_DEFAULTS: >-
         agent.api.stepsecurity.io:443
         github.com:443
@@ -89,7 +93,7 @@ jobs:
       issues: read
       id-token: write
     env:
-      # Built-in defaults — always applied, merged with inputs.harden_runner_allowed_endpoints
+      # Built-in endpoints — see first job above
       _HARDEN_DEFAULTS: >-
         agent.api.stepsecurity.io:443
         github.com:443

--- a/.github/workflows/lint-renovate.yml
+++ b/.github/workflows/lint-renovate.yml
@@ -36,7 +36,13 @@ jobs:
     permissions:
       contents: read
     env:
-      # Built-in defaults — always applied, merged with inputs.harden_runner_allowed_endpoints
+      # Built-in harden-runner allowed endpoints:
+      #   agent.api.stepsecurity.io:443 — harden-runner agent
+      #   api.github.com:443 — GitHub API (actions runtime)
+      #   github.com:443 — git clone, actions checkout
+      #   nodejs.org:443 — Node.js binary (actions/setup-node)
+      #   registry.npmjs.org:443 — npm packages (renovate-config-validator)
+      #   release-assets.githubusercontent.com:443 — GitHub release downloads
       _HARDEN_DEFAULTS: >-
         agent.api.stepsecurity.io:443
         github.com:443

--- a/.github/workflows/lint-renovate.yml
+++ b/.github/workflows/lint-renovate.yml
@@ -6,27 +6,27 @@ name: Lint Renovate Config
 on:
   workflow_call:
     inputs:
-      enable_harden_runner:
-        description: "Runtime security via StepSecurity harden-runner"
-        type: boolean
-        default: true
-      harden_runner_egress_policy:
-        description: "Harden-runner egress policy: audit (observe) or block (enforce allowlist)"
-        type: string
-        default: "audit"
-      harden_runner_allowed_endpoints:
-        description: "Extra endpoints to allow (merged with built-in defaults, space-separated)"
-        type: string
-        default: ""
-      node_version:
-        description: "Node.js version for renovate-config-validator"
-        type: string
-        default: "24"
       config_files:
         description: "Glob pattern of files to validate (default: *.json *.json5 at root)"
         type: string
         default: ""
 
+      enable_harden_runner:
+        description: "Runtime security via StepSecurity harden-runner"
+        type: boolean
+        default: true
+      harden_runner_allowed_endpoints:
+        description: "Extra endpoints to allow (merged with built-in defaults, space-separated)"
+        type: string
+        default: ""
+      harden_runner_egress_policy:
+        description: "Harden-runner egress policy: audit (observe) or block (enforce allowlist)"
+        type: string
+        default: "audit"
+      node_version:
+        description: "Node.js version for renovate-config-validator"
+        type: string
+        default: "24"
 permissions: {}
 
 jobs:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -57,8 +57,24 @@ jobs:
       contents: read
       security-events: write
     env:
-      # Built-in defaults — always applied, merged with inputs.harden_runner_allowed_endpoints
-      # 9236a389bd48b984df91adc1bc924620.r2.cloudflarestorage.com: KICS queries (Checkmarx R2 storage)
+      # Built-in harden-runner allowed endpoints:
+      #   9236a389bd48b984df91adc1bc924620.r2.cloudflarestorage.com:443 — KICS queries (Checkmarx R2 storage) — security.yml shared
+      #   agent.api.stepsecurity.io:443 — harden-runner agent
+      #   api.github.com:443 — GitHub API (actions runtime, SARIF upload)
+      #   api0.prismacloud.io:443 — Checkov policies (Prisma Cloud) — security.yml shared
+      #   apk.cgr.dev:443 — Chainguard APK packages (ansible-lint container)
+      #   files.pythonhosted.org:443 — pip packages (yamllint, json5)
+      #   get.trivy.dev:443 — Trivy install — security.yml shared
+      #   ghcr.io:443 — container images (ansible-lint)
+      #   github.com:443 — git clone, actions checkout
+      #   kics.io:443 — KICS scanner — security.yml shared
+      #   mirror.gcr.io:443 — GCR mirror — security.yml shared
+      #   pkg-containers.githubusercontent.com:443 — GHCR storage (ansible-lint container)
+      #   pypi.org:443 — pip index (yamllint, json5)
+      #   raw.githubusercontent.com:443 — actionlint SARIF template download
+      #   registry.npmjs.org:443 — npm packages (markdownlint-cli2-action)
+      #   release-assets.githubusercontent.com:443 — GitHub release downloads (actionlint, tflint)
+      #   releases.hashicorp.com:443 — Terraform binary (hashicorp/setup-terraform)
       _HARDEN_DEFAULTS: >-
         9236a389bd48b984df91adc1bc924620.r2.cloudflarestorage.com:443
         agent.api.stepsecurity.io:443
@@ -119,7 +135,7 @@ jobs:
     permissions:
       contents: read
     env:
-      # 9236a389bd48b984df91adc1bc924620.r2.cloudflarestorage.com: KICS queries (Checkmarx R2 storage)
+      # Built-in endpoints — see first job above
       _HARDEN_DEFAULTS: >-
         9236a389bd48b984df91adc1bc924620.r2.cloudflarestorage.com:443
         agent.api.stepsecurity.io:443
@@ -159,7 +175,7 @@ jobs:
     permissions:
       contents: read
     env:
-      # 9236a389bd48b984df91adc1bc924620.r2.cloudflarestorage.com: KICS queries (Checkmarx R2 storage)
+      # Built-in endpoints — see first job above
       _HARDEN_DEFAULTS: >-
         9236a389bd48b984df91adc1bc924620.r2.cloudflarestorage.com:443
         agent.api.stepsecurity.io:443
@@ -200,7 +216,7 @@ jobs:
     permissions:
       contents: read
     env:
-      # 9236a389bd48b984df91adc1bc924620.r2.cloudflarestorage.com: KICS queries (Checkmarx R2 storage)
+      # Built-in endpoints — see first job above
       _HARDEN_DEFAULTS: >-
         9236a389bd48b984df91adc1bc924620.r2.cloudflarestorage.com:443
         agent.api.stepsecurity.io:443
@@ -236,7 +252,7 @@ jobs:
     permissions:
       contents: read
     env:
-      # 9236a389bd48b984df91adc1bc924620.r2.cloudflarestorage.com: KICS queries (Checkmarx R2 storage)
+      # Built-in endpoints — see first job above
       _HARDEN_DEFAULTS: >-
         9236a389bd48b984df91adc1bc924620.r2.cloudflarestorage.com:443
         agent.api.stepsecurity.io:443
@@ -279,7 +295,7 @@ jobs:
     permissions:
       contents: read
     env:
-      # 9236a389bd48b984df91adc1bc924620.r2.cloudflarestorage.com: KICS queries (Checkmarx R2 storage)
+      # Built-in endpoints — see first job above
       _HARDEN_DEFAULTS: >-
         9236a389bd48b984df91adc1bc924620.r2.cloudflarestorage.com:443
         agent.api.stepsecurity.io:443

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,7 +4,7 @@ name: Lint
 # Usage: uses: trowaflo/github-actions/.github/workflows/lint.yml@<sha>
 #
 # Defaults on : actionlint = true (opt-out)
-# Defaults opt-in : markdown, yaml, ansible, terraform, json = false
+# Defaults opt-in : markdown, yaml, ansible, terraform, json, shellcheck, shfmt = false
 
 on:
   workflow_call:
@@ -28,6 +28,14 @@ on:
 
       enable_markdown_lint:
         description: "Lint Markdown with markdownlint-cli2"
+        type: boolean
+        default: false
+      enable_shellcheck:
+        description: "Lint shell scripts (bash/sh/zsh) with shellcheck via reviewdog (inline PR comments)"
+        type: boolean
+        default: false
+      enable_shfmt:
+        description: "Check shell script formatting with shfmt via reviewdog (inline PR comments)"
         type: boolean
         default: false
       enable_terraform_validate:
@@ -343,3 +351,66 @@ jobs:
             fi
           done < <(find . -name '*.json5' -not -path './.git/*' -not -path './node_modules/*' -print0)
           exit $exit_code
+
+  shellcheck:
+    if: ${{ inputs.enable_shellcheck }}
+    name: Lint Shell (shellcheck)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    env:
+      # Built-in harden-runner allowed endpoints:
+      #   agent.api.stepsecurity.io:443 — harden-runner agent
+      #   api.github.com:443            — reviewdog posts PR review comments
+      #   github.com:443                — checkout + shellcheck + reviewdog binaries
+      #   release-assets.githubusercontent.com:443 — binary downloads
+      _HARDEN_DEFAULTS: >-
+        agent.api.stepsecurity.io:443
+        api.github.com:443
+        github.com:443
+        release-assets.githubusercontent.com:443
+    steps:
+      - name: Harden Runner
+        if: ${{ inputs.enable_harden_runner }}
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        with:
+          egress-policy: ${{ inputs.harden_runner_egress_policy }}
+          allowed-endpoints: ${{ env._HARDEN_DEFAULTS }} ${{ inputs.harden_runner_allowed_endpoints }}
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: reviewdog/action-shellcheck@4c07458293ac342d477251099501a718ae5ef86e # v1.32.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          reporter: github-pr-review
+          filter_mode: added
+
+  shfmt:
+    if: ${{ inputs.enable_shfmt }}
+    name: Format Shell (shfmt)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    env:
+      # Built-in harden-runner allowed endpoints:
+      #   agent.api.stepsecurity.io:443 — harden-runner agent
+      #   api.github.com:443            — reviewdog posts PR suggestions
+      #   github.com:443                — checkout + shfmt + reviewdog binaries
+      #   release-assets.githubusercontent.com:443 — binary downloads
+      _HARDEN_DEFAULTS: >-
+        agent.api.stepsecurity.io:443
+        api.github.com:443
+        github.com:443
+        release-assets.githubusercontent.com:443
+    steps:
+      - name: Harden Runner
+        if: ${{ inputs.enable_harden_runner }}
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        with:
+          egress-policy: ${{ inputs.harden_runner_egress_policy }}
+          allowed-endpoints: ${{ env._HARDEN_DEFAULTS }} ${{ inputs.harden_runner_allowed_endpoints }}
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: reviewdog/action-shfmt@d8f080930b9be5847b4f97e9f4122b81a82aaeac # v1.0.4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          filter_mode: added

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -58,23 +58,25 @@ jobs:
       security-events: write
     env:
       # Built-in defaults — always applied, merged with inputs.harden_runner_allowed_endpoints
+      # 9236a389bd48b984df91adc1bc924620.r2.cloudflarestorage.com: KICS queries (Checkmarx R2 storage)
       _HARDEN_DEFAULTS: >-
+        9236a389bd48b984df91adc1bc924620.r2.cloudflarestorage.com:443
         agent.api.stepsecurity.io:443
-        github.com:443
         api.github.com:443
-        release-assets.githubusercontent.com:443
-        pypi.org:443
+        api0.prismacloud.io:443
+        apk.cgr.dev:443
         files.pythonhosted.org:443
+        get.trivy.dev:443
+        ghcr.io:443
+        github.com:443
+        kics.io:443
+        mirror.gcr.io:443
+        pkg-containers.githubusercontent.com:443
+        pypi.org:443
         raw.githubusercontent.com:443
         registry.npmjs.org:443
-        ghcr.io:443
-        pkg-containers.githubusercontent.com:443
-        get.trivy.dev:443
-        mirror.gcr.io:443
-        kics.io:443
-        apk.cgr.dev:443
-        9236a389bd48b984df91adc1bc924620.r2.cloudflarestorage.com:443
-        api0.prismacloud.io:443
+        release-assets.githubusercontent.com:443
+        releases.hashicorp.com:443
       # renovate: datasource=github-releases depName=rhysd/actionlint
       ACTIONLINT_VERSION: "1.7.12"
     steps:
@@ -117,23 +119,25 @@ jobs:
     permissions:
       contents: read
     env:
+      # 9236a389bd48b984df91adc1bc924620.r2.cloudflarestorage.com: KICS queries (Checkmarx R2 storage)
       _HARDEN_DEFAULTS: >-
+        9236a389bd48b984df91adc1bc924620.r2.cloudflarestorage.com:443
         agent.api.stepsecurity.io:443
-        github.com:443
         api.github.com:443
-        release-assets.githubusercontent.com:443
-        pypi.org:443
+        api0.prismacloud.io:443
+        apk.cgr.dev:443
         files.pythonhosted.org:443
+        get.trivy.dev:443
+        ghcr.io:443
+        github.com:443
+        kics.io:443
+        mirror.gcr.io:443
+        pkg-containers.githubusercontent.com:443
+        pypi.org:443
         raw.githubusercontent.com:443
         registry.npmjs.org:443
-        ghcr.io:443
-        pkg-containers.githubusercontent.com:443
-        get.trivy.dev:443
-        mirror.gcr.io:443
-        kics.io:443
-        apk.cgr.dev:443
-        9236a389bd48b984df91adc1bc924620.r2.cloudflarestorage.com:443
-        api0.prismacloud.io:443
+        release-assets.githubusercontent.com:443
+        releases.hashicorp.com:443
     steps:
       - name: Harden Runner
         if: ${{ inputs.enable_harden_runner }}
@@ -155,23 +159,25 @@ jobs:
     permissions:
       contents: read
     env:
+      # 9236a389bd48b984df91adc1bc924620.r2.cloudflarestorage.com: KICS queries (Checkmarx R2 storage)
       _HARDEN_DEFAULTS: >-
+        9236a389bd48b984df91adc1bc924620.r2.cloudflarestorage.com:443
         agent.api.stepsecurity.io:443
-        github.com:443
         api.github.com:443
-        release-assets.githubusercontent.com:443
-        pypi.org:443
+        api0.prismacloud.io:443
+        apk.cgr.dev:443
         files.pythonhosted.org:443
+        get.trivy.dev:443
+        ghcr.io:443
+        github.com:443
+        kics.io:443
+        mirror.gcr.io:443
+        pkg-containers.githubusercontent.com:443
+        pypi.org:443
         raw.githubusercontent.com:443
         registry.npmjs.org:443
-        ghcr.io:443
-        pkg-containers.githubusercontent.com:443
-        get.trivy.dev:443
-        mirror.gcr.io:443
-        kics.io:443
-        apk.cgr.dev:443
-        9236a389bd48b984df91adc1bc924620.r2.cloudflarestorage.com:443
-        api0.prismacloud.io:443
+        release-assets.githubusercontent.com:443
+        releases.hashicorp.com:443
     steps:
       - name: Harden Runner
         if: ${{ inputs.enable_harden_runner }}
@@ -194,23 +200,25 @@ jobs:
     permissions:
       contents: read
     env:
+      # 9236a389bd48b984df91adc1bc924620.r2.cloudflarestorage.com: KICS queries (Checkmarx R2 storage)
       _HARDEN_DEFAULTS: >-
+        9236a389bd48b984df91adc1bc924620.r2.cloudflarestorage.com:443
         agent.api.stepsecurity.io:443
-        github.com:443
         api.github.com:443
-        release-assets.githubusercontent.com:443
-        pypi.org:443
+        api0.prismacloud.io:443
+        apk.cgr.dev:443
         files.pythonhosted.org:443
+        get.trivy.dev:443
+        ghcr.io:443
+        github.com:443
+        kics.io:443
+        mirror.gcr.io:443
+        pkg-containers.githubusercontent.com:443
+        pypi.org:443
         raw.githubusercontent.com:443
         registry.npmjs.org:443
-        ghcr.io:443
-        pkg-containers.githubusercontent.com:443
-        get.trivy.dev:443
-        mirror.gcr.io:443
-        kics.io:443
-        apk.cgr.dev:443
-        9236a389bd48b984df91adc1bc924620.r2.cloudflarestorage.com:443
-        api0.prismacloud.io:443
+        release-assets.githubusercontent.com:443
+        releases.hashicorp.com:443
     steps:
       - name: Harden Runner
         if: ${{ inputs.enable_harden_runner }}
@@ -228,23 +236,25 @@ jobs:
     permissions:
       contents: read
     env:
+      # 9236a389bd48b984df91adc1bc924620.r2.cloudflarestorage.com: KICS queries (Checkmarx R2 storage)
       _HARDEN_DEFAULTS: >-
+        9236a389bd48b984df91adc1bc924620.r2.cloudflarestorage.com:443
         agent.api.stepsecurity.io:443
-        github.com:443
         api.github.com:443
-        release-assets.githubusercontent.com:443
-        pypi.org:443
+        api0.prismacloud.io:443
+        apk.cgr.dev:443
         files.pythonhosted.org:443
+        get.trivy.dev:443
+        ghcr.io:443
+        github.com:443
+        kics.io:443
+        mirror.gcr.io:443
+        pkg-containers.githubusercontent.com:443
+        pypi.org:443
         raw.githubusercontent.com:443
         registry.npmjs.org:443
-        ghcr.io:443
-        pkg-containers.githubusercontent.com:443
-        get.trivy.dev:443
-        mirror.gcr.io:443
-        kics.io:443
-        apk.cgr.dev:443
-        9236a389bd48b984df91adc1bc924620.r2.cloudflarestorage.com:443
-        api0.prismacloud.io:443
+        release-assets.githubusercontent.com:443
+        releases.hashicorp.com:443
     steps:
       - name: Harden Runner
         if: ${{ inputs.enable_harden_runner }}
@@ -269,23 +279,25 @@ jobs:
     permissions:
       contents: read
     env:
+      # 9236a389bd48b984df91adc1bc924620.r2.cloudflarestorage.com: KICS queries (Checkmarx R2 storage)
       _HARDEN_DEFAULTS: >-
+        9236a389bd48b984df91adc1bc924620.r2.cloudflarestorage.com:443
         agent.api.stepsecurity.io:443
-        github.com:443
         api.github.com:443
-        release-assets.githubusercontent.com:443
-        pypi.org:443
+        api0.prismacloud.io:443
+        apk.cgr.dev:443
         files.pythonhosted.org:443
+        get.trivy.dev:443
+        ghcr.io:443
+        github.com:443
+        kics.io:443
+        mirror.gcr.io:443
+        pkg-containers.githubusercontent.com:443
+        pypi.org:443
         raw.githubusercontent.com:443
         registry.npmjs.org:443
-        ghcr.io:443
-        pkg-containers.githubusercontent.com:443
-        get.trivy.dev:443
-        mirror.gcr.io:443
-        kics.io:443
-        apk.cgr.dev:443
-        9236a389bd48b984df91adc1bc924620.r2.cloudflarestorage.com:443
-        api0.prismacloud.io:443
+        release-assets.githubusercontent.com:443
+        releases.hashicorp.com:443
     steps:
       - name: Harden Runner
         if: ${{ inputs.enable_harden_runner }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,43 +9,43 @@ name: Lint
 on:
   workflow_call:
     inputs:
-      enable_harden_runner:
-        description: "Runtime security via StepSecurity harden-runner"
-        type: boolean
-        default: true
-      harden_runner_egress_policy:
-        description: "Harden-runner egress policy: audit (observe) or block (enforce allowlist)"
-        type: string
-        default: "audit"
-      harden_runner_allowed_endpoints:
-        description: "Extra endpoints to allow (merged with built-in defaults, space-separated)"
-        type: string
-        default: ""
       enable_actionlint:
         description: "Lint GitHub Actions workflow files"
         type: boolean
         default: true
-      enable_markdown_lint:
-        description: "Lint Markdown with markdownlint-cli2"
-        type: boolean
-        default: false
-      enable_yamllint:
-        description: "Lint YAML with yamllint (auto-detects .yamllint.yml)"
-        type: boolean
-        default: false
       enable_ansible_lint:
         description: "Lint Ansible with ansible-lint"
+        type: boolean
+        default: false
+      enable_harden_runner:
+        description: "Runtime security via StepSecurity harden-runner"
+        type: boolean
+        default: true
+      enable_json_lint:
+        description: "JSON and JSON5 syntax validation"
+        type: boolean
+        default: false
+
+      enable_markdown_lint:
+        description: "Lint Markdown with markdownlint-cli2"
         type: boolean
         default: false
       enable_terraform_validate:
         description: "Terraform validation: fmt check + tflint"
         type: boolean
         default: false
-      enable_json_lint:
-        description: "JSON and JSON5 syntax validation"
+      enable_yamllint:
+        description: "Lint YAML with yamllint (auto-detects .yamllint.yml)"
         type: boolean
         default: false
-
+      harden_runner_allowed_endpoints:
+        description: "Extra endpoints to allow (merged with built-in defaults, space-separated)"
+        type: string
+        default: ""
+      harden_runner_egress_policy:
+        description: "Harden-runner egress policy: audit (observe) or block (enforce allowlist)"
+        type: string
+        default: "audit"
 permissions: {}
 
 jobs:

--- a/.github/workflows/release-helm.yml
+++ b/.github/workflows/release-helm.yml
@@ -12,10 +12,10 @@ on:
         description: "Runtime security via StepSecurity harden-runner"
         type: boolean
         default: true
-      harden_runner_egress_policy:
-        description: "Harden-runner egress policy: audit (observe) or block (enforce allowlist)"
-        type: string
-        default: "audit"
+      enable_release:
+        description: "Release charts via chart-releaser (multi-dir support via release_charts_dirs)"
+        type: boolean
+        default: false
       harden_runner_allowed_endpoints:
         description: >-
           Extra endpoints to allow (merged with built-in defaults, space-separated).
@@ -23,16 +23,12 @@ on:
           add those hosts here if charts declare external repository URLs.
         type: string
         default: ""
-      enable_release:
-        description: "Release charts via chart-releaser (multi-dir support via release_charts_dirs)"
-        type: boolean
-        default: false
-      charts_dir:
-        description: "Root directory for Helm charts"
+      harden_runner_egress_policy:
+        description: "Harden-runner egress policy: audit (observe) or block (enforce allowlist)"
         type: string
-        default: "charts"
+        default: "audit"
       release_charts_dirs:
-        description: "Space-separated ordered chart directories to release (max 2, e.g., 'charts/library charts/apps'). If empty, uses charts_dir."
+        description: "Space-separated ordered chart directories to release (max 2, e.g., 'charts/library charts/apps'). Defaults to 'charts'."
         type: string
         default: ""
 
@@ -49,14 +45,14 @@ jobs:
     env:
       _HARDEN_DEFAULTS: >-
         agent.api.stepsecurity.io:443
-        github.com:443
         api.github.com:443
-        uploads.github.com:443
-        release-assets.githubusercontent.com:443
-        objects.githubusercontent.com:443
         get.helm.sh:443
-        tuf-repo-cdn.sigstore.dev:443
+        github.com:443
+        objects.githubusercontent.com:443
         rekor.sigstore.dev:443
+        release-assets.githubusercontent.com:443
+        tuf-repo-cdn.sigstore.dev:443
+        uploads.github.com:443
     steps:
       - name: Harden Runner
         if: ${{ inputs.enable_harden_runner }}
@@ -76,19 +72,14 @@ jobs:
         id: dirs
         env:
           RELEASE_DIRS: ${{ inputs.release_charts_dirs }}
-          CHARTS_DIR: ${{ inputs.charts_dir }}
         run: |
-          if [ -n "$RELEASE_DIRS" ]; then
-            count=$(echo "$RELEASE_DIRS" | wc -w | tr -d ' ')
-            if [ "$count" -gt 2 ]; then
-              echo "::warning::release_charts_dirs contains $count directories but only 2 are supported."
-            fi
-            echo "first=$(echo "$RELEASE_DIRS" | awk '{print $1}')" >> "$GITHUB_OUTPUT"
-            echo "second=$(echo "$RELEASE_DIRS" | awk '{print $2}')" >> "$GITHUB_OUTPUT"
-          else
-            echo "first=$CHARTS_DIR" >> "$GITHUB_OUTPUT"
-            echo "second=" >> "$GITHUB_OUTPUT"
+          DIRS="${RELEASE_DIRS:-charts}"
+          count=$(echo "$DIRS" | wc -w | tr -d ' ')
+          if [ "$count" -gt 2 ]; then
+            echo "::warning::release_charts_dirs contains $count directories but only 2 are supported."
           fi
+          echo "first=$(echo "$DIRS" | awk '{print $1}')" >> "$GITHUB_OUTPUT"
+          echo "second=$(echo "$DIRS" | awk '{print $2}')" >> "$GITHUB_OUTPUT"
       - name: Install yq with checksum verification
         run: |
           set -euo pipefail

--- a/.github/workflows/release-helm.yml
+++ b/.github/workflows/release-helm.yml
@@ -43,6 +43,16 @@ jobs:
       contents: write
       pages: write
     env:
+      # Built-in harden-runner allowed endpoints:
+      #   agent.api.stepsecurity.io:443 — harden-runner agent
+      #   api.github.com:443 — GitHub API (chart-releaser)
+      #   get.helm.sh:443 — Helm binary (azure/setup-helm)
+      #   github.com:443 — git clone, actions checkout
+      #   objects.githubusercontent.com:443 — GitHub release assets (yq binary)
+      #   rekor.sigstore.dev:443 — Sigstore transparency log (cosign verification)
+      #   release-assets.githubusercontent.com:443 — GitHub release downloads (yq checksums)
+      #   tuf-repo-cdn.sigstore.dev:443 — Sigstore TUF metadata (cosign verification)
+      #   uploads.github.com:443 — GitHub release uploads (chart-releaser)
       _HARDEN_DEFAULTS: >-
         agent.api.stepsecurity.io:443
         api.github.com:443

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -18,3 +18,4 @@ jobs:
       pull-requests: write
     with:
       enable_release_please: true
+      harden_runner_egress_policy: block

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,10 @@ jobs:
       contents: write
       pull-requests: write
     env:
-      # Built-in defaults — always applied, merged with inputs.harden_runner_allowed_endpoints
+      # Built-in harden-runner allowed endpoints:
+      #   agent.api.stepsecurity.io:443 — harden-runner agent
+      #   api.github.com:443 — GitHub API (release-please)
+      #   github.com:443 — git clone, actions checkout
       _HARDEN_DEFAULTS: >-
         agent.api.stepsecurity.io:443
         github.com:443

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,18 +12,18 @@ on:
         description: "Runtime security via StepSecurity harden-runner"
         type: boolean
         default: true
-      harden_runner_egress_policy:
-        description: "Harden-runner egress policy: audit (observe) or block (enforce allowlist)"
-        type: string
-        default: "audit"
-      harden_runner_allowed_endpoints:
-        description: "Extra endpoints to allow (merged with built-in defaults, space-separated)"
-        type: string
-        default: ""
       enable_release_please:
         description: "Automated releases via release-please"
         type: boolean
         default: false
+      harden_runner_allowed_endpoints:
+        description: "Extra endpoints to allow (merged with built-in defaults, space-separated)"
+        type: string
+        default: ""
+      harden_runner_egress_policy:
+        description: "Harden-runner egress policy: audit (observe) or block (enforce allowlist)"
+        type: string
+        default: "audit"
       release_config_file:
         description: "Path to release-please-config.json"
         type: string

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -62,23 +62,24 @@ jobs:
       pull-requests: write
     env:
       # Built-in defaults — always applied, merged with inputs.harden_runner_allowed_endpoints
+      # 9236a389bd48b984df91adc1bc924620.r2.cloudflarestorage.com: KICS queries (Checkmarx R2 storage)
       _HARDEN_DEFAULTS: >-
+        9236a389bd48b984df91adc1bc924620.r2.cloudflarestorage.com:443
         agent.api.stepsecurity.io:443
-        github.com:443
         api.github.com:443
-        release-assets.githubusercontent.com:443
-        pypi.org:443
+        api0.prismacloud.io:443
+        apk.cgr.dev:443
         files.pythonhosted.org:443
+        get.trivy.dev:443
+        ghcr.io:443
+        github.com:443
+        kics.io:443
+        mirror.gcr.io:443
+        pkg-containers.githubusercontent.com:443
+        pypi.org:443
         raw.githubusercontent.com:443
         registry.npmjs.org:443
-        ghcr.io:443
-        pkg-containers.githubusercontent.com:443
-        get.trivy.dev:443
-        mirror.gcr.io:443
-        kics.io:443
-        apk.cgr.dev:443
-        9236a389bd48b984df91adc1bc924620.r2.cloudflarestorage.com:443
-        api0.prismacloud.io:443
+        release-assets.githubusercontent.com:443
     steps:
       - name: Harden Runner
         if: ${{ inputs.enable_harden_runner }}
@@ -103,23 +104,24 @@ jobs:
       security-events: write
     env:
       # Built-in defaults — always applied, merged with inputs.harden_runner_allowed_endpoints
+      # 9236a389bd48b984df91adc1bc924620.r2.cloudflarestorage.com: KICS queries (Checkmarx R2 storage)
       _HARDEN_DEFAULTS: >-
+        9236a389bd48b984df91adc1bc924620.r2.cloudflarestorage.com:443
         agent.api.stepsecurity.io:443
-        github.com:443
         api.github.com:443
-        release-assets.githubusercontent.com:443
-        pypi.org:443
+        api0.prismacloud.io:443
+        apk.cgr.dev:443
         files.pythonhosted.org:443
+        get.trivy.dev:443
+        ghcr.io:443
+        github.com:443
+        kics.io:443
+        mirror.gcr.io:443
+        pkg-containers.githubusercontent.com:443
+        pypi.org:443
         raw.githubusercontent.com:443
         registry.npmjs.org:443
-        ghcr.io:443
-        pkg-containers.githubusercontent.com:443
-        get.trivy.dev:443
-        mirror.gcr.io:443
-        kics.io:443
-        apk.cgr.dev:443
-        9236a389bd48b984df91adc1bc924620.r2.cloudflarestorage.com:443
-        api0.prismacloud.io:443
+        release-assets.githubusercontent.com:443
     steps:
       - name: Harden Runner
         if: ${{ inputs.enable_harden_runner }}
@@ -156,23 +158,24 @@ jobs:
       pull-requests: write
     env:
       # Built-in defaults — always applied, merged with inputs.harden_runner_allowed_endpoints
+      # 9236a389bd48b984df91adc1bc924620.r2.cloudflarestorage.com: KICS queries (Checkmarx R2 storage)
       _HARDEN_DEFAULTS: >-
+        9236a389bd48b984df91adc1bc924620.r2.cloudflarestorage.com:443
         agent.api.stepsecurity.io:443
-        github.com:443
         api.github.com:443
-        release-assets.githubusercontent.com:443
-        pypi.org:443
+        api0.prismacloud.io:443
+        apk.cgr.dev:443
         files.pythonhosted.org:443
+        get.trivy.dev:443
+        ghcr.io:443
+        github.com:443
+        kics.io:443
+        mirror.gcr.io:443
+        pkg-containers.githubusercontent.com:443
+        pypi.org:443
         raw.githubusercontent.com:443
         registry.npmjs.org:443
-        ghcr.io:443
-        pkg-containers.githubusercontent.com:443
-        get.trivy.dev:443
-        mirror.gcr.io:443
-        kics.io:443
-        apk.cgr.dev:443
-        9236a389bd48b984df91adc1bc924620.r2.cloudflarestorage.com:443
-        api0.prismacloud.io:443
+        release-assets.githubusercontent.com:443
     steps:
       - name: Harden Runner
         if: ${{ inputs.enable_harden_runner }}
@@ -192,23 +195,24 @@ jobs:
       security-events: write
     env:
       # Built-in defaults — always applied, merged with inputs.harden_runner_allowed_endpoints
+      # 9236a389bd48b984df91adc1bc924620.r2.cloudflarestorage.com: KICS queries (Checkmarx R2 storage)
       _HARDEN_DEFAULTS: >-
+        9236a389bd48b984df91adc1bc924620.r2.cloudflarestorage.com:443
         agent.api.stepsecurity.io:443
-        github.com:443
         api.github.com:443
-        release-assets.githubusercontent.com:443
-        pypi.org:443
+        api0.prismacloud.io:443
+        apk.cgr.dev:443
         files.pythonhosted.org:443
+        get.trivy.dev:443
+        ghcr.io:443
+        github.com:443
+        kics.io:443
+        mirror.gcr.io:443
+        pkg-containers.githubusercontent.com:443
+        pypi.org:443
         raw.githubusercontent.com:443
         registry.npmjs.org:443
-        ghcr.io:443
-        pkg-containers.githubusercontent.com:443
-        get.trivy.dev:443
-        mirror.gcr.io:443
-        kics.io:443
-        apk.cgr.dev:443
-        9236a389bd48b984df91adc1bc924620.r2.cloudflarestorage.com:443
-        api0.prismacloud.io:443
+        release-assets.githubusercontent.com:443
     steps:
       - name: Harden Runner
         if: ${{ inputs.enable_harden_runner }}
@@ -240,23 +244,24 @@ jobs:
       security-events: write
     env:
       # Built-in defaults — always applied, merged with inputs.harden_runner_allowed_endpoints
+      # 9236a389bd48b984df91adc1bc924620.r2.cloudflarestorage.com: KICS queries (Checkmarx R2 storage)
       _HARDEN_DEFAULTS: >-
+        9236a389bd48b984df91adc1bc924620.r2.cloudflarestorage.com:443
         agent.api.stepsecurity.io:443
-        github.com:443
         api.github.com:443
-        release-assets.githubusercontent.com:443
-        pypi.org:443
+        api0.prismacloud.io:443
+        apk.cgr.dev:443
         files.pythonhosted.org:443
+        get.trivy.dev:443
+        ghcr.io:443
+        github.com:443
+        kics.io:443
+        mirror.gcr.io:443
+        pkg-containers.githubusercontent.com:443
+        pypi.org:443
         raw.githubusercontent.com:443
         registry.npmjs.org:443
-        ghcr.io:443
-        pkg-containers.githubusercontent.com:443
-        get.trivy.dev:443
-        mirror.gcr.io:443
-        kics.io:443
-        apk.cgr.dev:443
-        9236a389bd48b984df91adc1bc924620.r2.cloudflarestorage.com:443
-        api0.prismacloud.io:443
+        release-assets.githubusercontent.com:443
     steps:
       - name: Harden Runner
         if: ${{ inputs.enable_harden_runner }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -9,42 +9,42 @@ name: Security
 on:
   workflow_call:
     inputs:
-      enable_harden_runner:
-        description: "Runtime security via StepSecurity harden-runner"
-        type: boolean
-        default: true
-      harden_runner_egress_policy:
-        description: "Harden-runner egress policy: audit (observe) or block (enforce allowlist)"
-        type: string
-        default: "audit"
-      harden_runner_allowed_endpoints:
-        description: "Extra endpoints to allow (merged with built-in defaults, space-separated)"
+      checkov_framework:
+        description: "Checkov framework: terraform, kubernetes, helm, dockerfile, or empty for all"
         type: string
         default: ""
+      enable_checkov:
+        description: "IaC misconfiguration scanning with Checkov"
+        type: boolean
+        default: false
+      enable_dependency_review:
+        description: "Dependency review on PR — requires pull_request event"
+        type: boolean
+        default: false
       enable_gitleaks:
         description: "Secret scanning with gitleaks"
+        type: boolean
+        default: true
+      enable_harden_runner:
+        description: "Runtime security via StepSecurity harden-runner"
         type: boolean
         default: true
       enable_kics:
         description: "IaC scanning with KICS"
         type: boolean
         default: true
-      enable_dependency_review:
-        description: "Dependency review on PR — requires pull_request event"
-        type: boolean
-        default: false
-      enable_checkov:
-        description: "IaC misconfiguration scanning with Checkov"
-        type: boolean
-        default: false
-      checkov_framework:
-        description: "Checkov framework: terraform, kubernetes, helm, dockerfile, or empty for all"
-        type: string
-        default: ""
       enable_trivy:
         description: "IaC/filesystem scanning with Trivy"
         type: boolean
         default: false
+      harden_runner_allowed_endpoints:
+        description: "Extra endpoints to allow (merged with built-in defaults, space-separated)"
+        type: string
+        default: ""
+      harden_runner_egress_policy:
+        description: "Harden-runner egress policy: audit (observe) or block (enforce allowlist)"
+        type: string
+        default: "audit"
       trivy_severity:
         description: "Trivy severity levels: UNKNOWN, LOW, MEDIUM, HIGH, CRITICAL"
         type: string

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -61,8 +61,23 @@ jobs:
       contents: read
       pull-requests: write
     env:
-      # Built-in defaults — always applied, merged with inputs.harden_runner_allowed_endpoints
-      # 9236a389bd48b984df91adc1bc924620.r2.cloudflarestorage.com: KICS queries (Checkmarx R2 storage)
+      # Built-in harden-runner allowed endpoints:
+      #   9236a389bd48b984df91adc1bc924620.r2.cloudflarestorage.com:443 — KICS queries (Checkmarx R2 storage)
+      #   agent.api.stepsecurity.io:443 — harden-runner agent
+      #   api.github.com:443 — GitHub API (actions runtime, SARIF upload, dependency-review)
+      #   api0.prismacloud.io:443 — Checkov policies (Prisma Cloud API)
+      #   apk.cgr.dev:443 — Chainguard APK packages (KICS container)
+      #   files.pythonhosted.org:443 — pip packages (checkov)
+      #   get.trivy.dev:443 — Trivy install script (trivy-action)
+      #   ghcr.io:443 — container images (KICS, gitleaks)
+      #   github.com:443 — git clone, actions checkout
+      #   kics.io:443 — KICS scanner queries download
+      #   mirror.gcr.io:443 — GCR mirror (Docker daemon)
+      #   pkg-containers.githubusercontent.com:443 — GHCR storage backend
+      #   pypi.org:443 — pip index (checkov)
+      #   raw.githubusercontent.com:443 — GitHub raw content (gitleaks config)
+      #   registry.npmjs.org:443 — npm packages (dependency-review-action)
+      #   release-assets.githubusercontent.com:443 — GitHub release downloads
       _HARDEN_DEFAULTS: >-
         9236a389bd48b984df91adc1bc924620.r2.cloudflarestorage.com:443
         agent.api.stepsecurity.io:443
@@ -103,8 +118,7 @@ jobs:
       pull-requests: write
       security-events: write
     env:
-      # Built-in defaults — always applied, merged with inputs.harden_runner_allowed_endpoints
-      # 9236a389bd48b984df91adc1bc924620.r2.cloudflarestorage.com: KICS queries (Checkmarx R2 storage)
+      # Built-in endpoints — see first job above
       _HARDEN_DEFAULTS: >-
         9236a389bd48b984df91adc1bc924620.r2.cloudflarestorage.com:443
         agent.api.stepsecurity.io:443
@@ -157,8 +171,7 @@ jobs:
       contents: read
       pull-requests: write
     env:
-      # Built-in defaults — always applied, merged with inputs.harden_runner_allowed_endpoints
-      # 9236a389bd48b984df91adc1bc924620.r2.cloudflarestorage.com: KICS queries (Checkmarx R2 storage)
+      # Built-in endpoints — see first job above
       _HARDEN_DEFAULTS: >-
         9236a389bd48b984df91adc1bc924620.r2.cloudflarestorage.com:443
         agent.api.stepsecurity.io:443
@@ -194,8 +207,7 @@ jobs:
       contents: read
       security-events: write
     env:
-      # Built-in defaults — always applied, merged with inputs.harden_runner_allowed_endpoints
-      # 9236a389bd48b984df91adc1bc924620.r2.cloudflarestorage.com: KICS queries (Checkmarx R2 storage)
+      # Built-in endpoints — see first job above
       _HARDEN_DEFAULTS: >-
         9236a389bd48b984df91adc1bc924620.r2.cloudflarestorage.com:443
         agent.api.stepsecurity.io:443
@@ -243,8 +255,7 @@ jobs:
       contents: read
       security-events: write
     env:
-      # Built-in defaults — always applied, merged with inputs.harden_runner_allowed_endpoints
-      # 9236a389bd48b984df91adc1bc924620.r2.cloudflarestorage.com: KICS queries (Checkmarx R2 storage)
+      # Built-in endpoints — see first job above
       _HARDEN_DEFAULTS: >-
         9236a389bd48b984df91adc1bc924620.r2.cloudflarestorage.com:443
         agent.api.stepsecurity.io:443

--- a/.github/workflows/test-docker.yml
+++ b/.github/workflows/test-docker.yml
@@ -1,7 +1,7 @@
 name: Test Docker Workflow
 
 # Validates ci-docker.yml using the hello-world test fixture in tests/docker/.
-# Builds the image, then runs both Trivy and grype scans on it.
+# Builds the image, then runs Trivy scan on it.
 #
 # Triggered:
 #   - workflow_dispatch (manual)
@@ -15,7 +15,7 @@ permissions: {}
 
 jobs:
   docker:
-    name: Test ci-docker.yml (build + trivy + grype)
+    name: Test ci-docker.yml (build + trivy)
     uses: ./.github/workflows/ci-docker.yml
     permissions:
       contents: read
@@ -24,7 +24,4 @@ jobs:
     with:
       enable_build: true
       enable_trivy: true
-      enable_grype: true
-      grype_severity_cutoff: high
-      # audit mode: observe egress without blocking — surface any missing endpoints
       harden_runner_egress_policy: block

--- a/.github/workflows/test-docker.yml
+++ b/.github/workflows/test-docker.yml
@@ -22,6 +22,5 @@ jobs:
       packages: write
       security-events: write
     with:
-      enable_build: true
       enable_trivy: true
       harden_runner_egress_policy: block

--- a/.github/workflows/test-docker.yml
+++ b/.github/workflows/test-docker.yml
@@ -27,4 +27,4 @@ jobs:
       enable_grype: true
       grype_severity_cutoff: high
       # audit mode: observe egress without blocking — surface any missing endpoints
-      harden_runner_egress_policy: audit
+      harden_runner_egress_policy: block

--- a/.github/workflows/test-ha.yml
+++ b/.github/workflows/test-ha.yml
@@ -26,3 +26,4 @@ jobs:
       ha_version: "stable"
       config_check_setup: "cp tests/ha/configuration.yaml ."
       hacs_ignore: "brands topics"
+      harden_runner_egress_policy: block

--- a/.github/workflows/test-helm.yml
+++ b/.github/workflows/test-helm.yml
@@ -39,7 +39,6 @@ jobs:
       pages: write
     with:
       enable_release: true
-      charts_dir: tests/charts
       harden_runner_egress_policy: block
 
   helm-pr-cleanup:

--- a/.github/workflows/test-helm.yml
+++ b/.github/workflows/test-helm.yml
@@ -29,6 +29,7 @@ jobs:
       enable_docs_check: true
       enable_pr_charts: true
       charts_dir: tests/charts
+      harden_runner_egress_policy: block
 
   helm-release:
     name: Test release-helm.yml
@@ -39,6 +40,7 @@ jobs:
     with:
       enable_release: true
       charts_dir: tests/charts
+      harden_runner_egress_policy: block
 
   helm-pr-cleanup:
     name: Test ci-helm-cleanup.yml
@@ -49,3 +51,4 @@ jobs:
       pull-requests: write
     with:
       skip_event_check: true
+      harden_runner_egress_policy: block

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -25,3 +25,4 @@ jobs:
       test_path: "tests/python/"
       coverage_path: "tests/python"
       coverage_threshold: "80"
+      harden_runner_egress_policy: block

--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -23,3 +23,4 @@ jobs:
       pull-requests: write
     with:
       enable_release_please: true
+      harden_runner_egress_policy: block

--- a/.github/workflows/test-validate-renovate.yml
+++ b/.github/workflows/test-validate-renovate.yml
@@ -18,3 +18,5 @@ jobs:
     uses: ./.github/workflows/lint-renovate.yml
     permissions:
       contents: read
+    with:
+      harden_runner_egress_policy: block

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ This repository is the **source of truth** for all GitHub Actions workflows acro
   ci-python.yml        # Python CI: pytest+ruff+codecov (generic — HA uses extra_packages)
   ci-helm.yml          # Helm CI: lint, unittest, bump, docs, docs-check, pr-charts (pull_request)
   ci-helm-cleanup.yml  # Helm Cleanup: remove pr-charts on PR close
-  ci-docker.yml        # Docker: build/push, trivy scan, grype scan
+  ci-docker.yml        # Docker: build/push, trivy scan
   release.yml          # Release: release-please
   release-helm.yml     # Helm Release: chart-releaser (push to main)
   claude-code.yml      # Claude Code: @claude mentions + /review command
@@ -33,7 +33,7 @@ This repository is the **source of truth** for all GitHub Actions workflows acro
   test-ha.yml          # Tests ci-ha.yml: hacs, hassfest, config-check
   test-python.yml      # Tests ci-python.yml: pytest, ruff
   test-helm.yml        # Tests ci-helm.yml + release-helm.yml + ci-helm-cleanup.yml
-  test-docker.yml      # Tests ci-docker.yml: build, trivy (container), grype
+  test-docker.yml      # Tests ci-docker.yml: build, trivy (container)
   test-validate-renovate.yml  # Tests lint-renovate.yml
   test-release.yml     # Tests release.yml (dry-run mode)
 
@@ -103,14 +103,9 @@ KICS is available in `security.yml` via `enable_kics` (default: `true`). Note: `
 
 `security.yml` provides `enable_trivy` for IaC/filesystem scanning via `aquasecurity/trivy-action`. Severity is configurable via `trivy_severity` (default: all levels). This is independent from the container Trivy scan in `ci-docker.yml`.
 
-### Container scanning (Trivy vs grype)
+### Container scanning (Trivy)
 
-`ci-docker.yml` provides two independent container scanning jobs:
-
-- `enable_trivy` — aquasecurity/trivy-action, SHA-pinned post-incident
-- `enable_grype` — anchore/scan-action, never impacted by TeamPCP
-
-Both are `false` by default. Enable one, both, or neither depending on the repo.
+`ci-docker.yml` provides Trivy container scanning via `aquasecurity/trivy-action`. Trivy outputs a readable table in logs and uploads SARIF for Code Scanning integration. It is `false` by default — enable with `enable_trivy: true`.
 
 ## Consumer usage example
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,3 +147,7 @@ All inputs (including secrets) are documented inline in each workflow file — r
 
 Key files: `security.yml`, `lint.yml`, `lint-renovate.yml`, `ci-ha.yml`, `ci-python.yml`, `ci-helm.yml`, `ci-helm-cleanup.yml`, `ci-docker.yml`, `release.yml`, `release-helm.yml`, `claude-code.yml`
 
+## Documentation
+
+Every reusable workflow has a matching doc file in `docs/` (e.g. `ci-docker.yml` → `docs/ci-docker.md`). **When modifying a workflow, always update the corresponding doc file** — inputs table, usage examples, and notes must stay in sync. Also update `CLAUDE.md` if the change affects architecture, conventions, or the repository structure section.
+

--- a/docs/ci-docker.md
+++ b/docs/ci-docker.md
@@ -6,7 +6,7 @@ Tous les jobs sont **désactivés par défaut** (opt-in explicite).
 
 ## Ordre d'exécution
 
-Quand `enable_build: true`, le workflow garantit l'ordre **build → scan → publish** :
+Le workflow garantit l'ordre **build → scan → publish** :
 
 1. Build l'image avec un tag staging temporaire (`:scan-{run_id}`)
 2. Scan Trivy sur ce tag staging
@@ -17,41 +17,15 @@ Le tag staging (`:scan-{run_id}`) reste dans le registre après le workflow. Il 
 
 ## Usage
 
-### Build + scan (recommandé)
-
 ```yaml
-jobs:
-  docker:
-    uses: trowaflo/github-actions/.github/workflows/ci-docker.yml@<sha> # vX.Y.Z
-    with:
-      enable_build: true
-      enable_trivy: true
-    secrets:
-      registry_username: ${{ secrets.REGISTRY_USER }}    # optionnel pour ghcr.io
-      registry_password: ${{ secrets.REGISTRY_TOKEN }}   # optionnel pour ghcr.io
-```
-
-### Scan uniquement (image existante)
-
-Mode `enable_build: false` : scanner une image déjà dans le registre, sans rebuilder.
-
-Deux cas d'usage principaux :
-
-- **Scan planifié** — détecter les nouvelles CVEs sur des images en production, sans attendre un nouveau build. Une CVE publiée aujourd'hui peut affecter une image buildée il y a 2 semaines.
-- **Scan de base image** — vérifier une image tierce (`nginx:alpine`, `python:3.13-slim`) avant de builder dessus.
-
-```yaml
-# Scan quotidien sur les images en production
-on:
-  schedule:
-    - cron: '0 6 * * *'
-
 jobs:
   docker:
     uses: trowaflo/github-actions/.github/workflows/ci-docker.yml@<sha> # vX.Y.Z
     with:
       enable_trivy: true
-      image_name: "ghcr.io/trowaflo/my-image:latest"
+    secrets:
+      registry_username: ${{ secrets.REGISTRY_USER }}    # optionnel pour ghcr.io
+      registry_password: ${{ secrets.REGISTRY_TOKEN }}   # optionnel pour ghcr.io
 ```
 
 ## Inputs
@@ -61,10 +35,8 @@ jobs:
 | `enable_harden_runner` | boolean | `true` | Runtime security via StepSecurity harden-runner |
 | `harden_runner_egress_policy` | string | `"audit"` | Egress policy: `audit` (observe) or `block` (enforce allowlist) |
 | `harden_runner_allowed_endpoints` | string | `(built-in)` | Allowed endpoints when block (space-separated) — extra endpoints merged with defaults |
-| `enable_build` | boolean | `false` | Docker build & push via bake |
 | `enable_trivy` | boolean | `false` | CVE scan via Trivy (aquasecurity) |
 | `registry` | string | `"ghcr.io"` | Registre Docker cible |
-| `image_name` | string | `""` | Nom de l'image — défaut : `{registry}/{github.repository}` |
 | `trivy_severity` | string | `""` | Sévérités Trivy à remonter (vide = toutes) |
 
 ## Secrets

--- a/docs/ci-docker.md
+++ b/docs/ci-docker.md
@@ -1,6 +1,6 @@
 # ci-docker.yml
 
-Docker Build & Container Scanning — build/push via bake, CVE scanning avec Trivy et grype.
+Docker Build & Container Scanning — build/push via bake, CVE scanning avec Trivy.
 
 Tous les jobs sont **désactivés par défaut** (opt-in explicite).
 
@@ -9,9 +9,9 @@ Tous les jobs sont **désactivés par défaut** (opt-in explicite).
 Quand `enable_build: true`, le workflow garantit l'ordre **build → scan → publish** :
 
 1. Build l'image avec un tag staging temporaire (`:scan-{run_id}`)
-2. Scan Trivy et/ou grype sur ce tag staging
-3. Si tous les scans passent : publish final avec les tags définis dans le bake file
-4. Si un scan échoue : le job s'arrête — **le publish n'a pas lieu**
+2. Scan Trivy sur ce tag staging
+3. Si le scan passe : publish final avec les tags définis dans le bake file
+4. Si le scan échoue : le job s'arrête — **le publish n'a pas lieu**
 
 Le tag staging (`:scan-{run_id}`) reste dans le registre après le workflow. Il peut être nettoyé par des politiques de rétention du registre (ghcr.io : 90 jours pour les packages non utilisés).
 
@@ -26,7 +26,6 @@ jobs:
     with:
       enable_build: true
       enable_trivy: true
-      enable_grype: true
     secrets:
       registry_username: ${{ secrets.REGISTRY_USER }}    # optionnel pour ghcr.io
       registry_password: ${{ secrets.REGISTRY_TOKEN }}   # optionnel pour ghcr.io
@@ -52,7 +51,6 @@ jobs:
     uses: trowaflo/github-actions/.github/workflows/ci-docker.yml@<sha> # vX.Y.Z
     with:
       enable_trivy: true
-      enable_grype: true
       image_name: "ghcr.io/trowaflo/my-image:latest"
 ```
 
@@ -65,11 +63,9 @@ jobs:
 | `harden_runner_allowed_endpoints` | string | `(built-in)` | Allowed endpoints when block (space-separated) — extra endpoints merged with defaults |
 | `enable_build` | boolean | `false` | Docker build & push via bake |
 | `enable_trivy` | boolean | `false` | CVE scan via Trivy (aquasecurity) |
-| `enable_grype` | boolean | `false` | CVE scan via grype (Anchore/Cisco) |
 | `registry` | string | `"ghcr.io"` | Registre Docker cible |
 | `image_name` | string | `""` | Nom de l'image — défaut : `{registry}/{github.repository}` |
 | `trivy_severity` | string | `""` | Sévérités Trivy à remonter (vide = toutes) |
-| `grype_severity_cutoff` | string | `""` | Sévérité minimale grype : `negligible`, `low`, `medium`, `high`, `critical` |
 
 ## Secrets
 
@@ -87,17 +83,6 @@ Ce workflow délègue entièrement au `docker-bake.hcl` (ou `compose.yml`) du re
 ### Multi-platform
 
 QEMU est configuré automatiquement. Les platforms cibles sont définies dans le bake file du consumer.
-
-### Trivy vs grype
-
-Les deux scanners sont indépendants et complémentaires :
-
-| | Trivy | grype |
-| --- | --- | --- |
-| Éditeur | aquasecurity | Anchore (Cisco) |
-| Base de données | NVD, GitHub Advisory, OS advisories | Grype DB (NVD + OS) |
-
-Activer les deux permet de comparer la couverture dans le temps.
 
 ### ghcr.io
 

--- a/docs/helm.md
+++ b/docs/helm.md
@@ -71,7 +71,6 @@ jobs:
       pages: write
     with:
       enable_release: true
-      charts_dir: "charts"
 ```
 
 ### Inputs
@@ -82,8 +81,7 @@ jobs:
 | `harden_runner_egress_policy` | string | `"audit"` | Egress policy: `audit` or `block` |
 | `harden_runner_allowed_endpoints` | string | (built-in) | Extra endpoints merged with defaults |
 | `enable_release` | boolean | `false` | Release via chart-releaser |
-| `charts_dir` | string | `"charts"` | Répertoire racine des charts |
-| `release_charts_dirs` | string | `""` | Répertoires de charts à releaser (max 2, space-separated) |
+| `release_charts_dirs` | string | `""` | Répertoires de charts à releaser (max 2, space-separated). Defaults to `charts` |
 
 ---
 

--- a/docs/lint.md
+++ b/docs/lint.md
@@ -30,6 +30,8 @@ jobs:
 | `enable_yamllint` | boolean | `false` | Lint YAML avec yamllint |
 | `enable_json_lint` | boolean | `false` | Validation syntaxe JSON et JSON5 |
 | `enable_ansible_lint` | boolean | `false` | Lint Ansible avec ansible-lint |
+| `enable_shellcheck` | boolean | `false` | Lint scripts shell (bash/sh/zsh) avec shellcheck via reviewdog (inline PR comments) |
+| `enable_shfmt` | boolean | `false` | Vérification du formatage des scripts shell avec shfmt via reviewdog (inline PR suggestions) |
 | `enable_terraform_validate` | boolean | `false` | `terraform fmt` + `tflint` |
 
 ## Permissions requises
@@ -38,6 +40,7 @@ jobs:
 | --- | --- |
 | `contents: read` | Tous les jobs (checkout) |
 | `security-events: write` | actionlint (upload SARIF) |
+| `pull-requests: write` | shellcheck, shfmt (reviewdog inline comments) |
 
 ## Secrets
 
@@ -58,6 +61,20 @@ Valide la syntaxe de tous les fichiers `*.json` (via `json.load`) et `*.json5` (
 ### yamllint
 
 Créer un `.yamllint.yml` à la racine du repo pour surcharger la configuration par défaut.
+
+### shellcheck
+
+Analyse statique des scripts shell (bash/sh/zsh) via [`reviewdog/action-shellcheck`](https://github.com/reviewdog/action-shellcheck). Détecte les erreurs courantes et les problèmes de sécurité (variables non quotées, injections via `eval`, etc.).
+
+Résultats postés en inline review comments sur la PR. Seuls les fichiers modifiés par la PR sont analysés (`filter_mode: added`).
+
+Par défaut, scanne les fichiers `*.sh`. Pour inclure aussi les scripts sans extension mais avec un shebang, activer `check_all_files_with_shebangs` via `shellcheck_flags`.
+
+### shfmt
+
+Vérification du formatage des scripts shell via [`reviewdog/action-shfmt`](https://github.com/reviewdog/action-shfmt). Poste des suggestions de correction directement dans la PR (inline suggestions applicables en un clic).
+
+Par défaut : indentation 2 espaces, `case` indenté (`-i 2 -ci`). Configurable via l'input `shfmt_flags` si nécessaire.
 
 ### harden-runner
 

--- a/tests/terraform/main.tf
+++ b/tests/terraform/main.tf
@@ -4,4 +4,5 @@ terraform {
 
 output "hello" {
   value = "Hello, World!"
+  description = "A friendly greeting"
 }

--- a/tests/terraform/main.tf
+++ b/tests/terraform/main.tf
@@ -3,6 +3,6 @@ terraform {
 }
 
 output "hello" {
-  value = "Hello, World!"
+  value       = "Hello, World!"
   description = "A friendly greeting"
 }


### PR DESCRIPTION
## Summary

- Adds `enable_shellcheck` (opt-in, default `false`) — lints bash/sh/zsh scripts with `reviewdog/action-shellcheck` v1.32.0, posts inline review comments on PRs
- Adds `enable_shfmt` (opt-in, default `false`) — checks shell script formatting with `reviewdog/action-shfmt` v1.0.4, posts inline suggestions applicable in one click
- Both jobs use a minimal `_HARDEN_DEFAULTS` (4 endpoints) instead of the full shared list — only what reviewdog actually needs
- Requires `pull-requests: write` on consumer side when either is enabled

## Test plan

- [ ] Enable `enable_shellcheck: true` in a consumer repo with `.sh` files containing shellcheck warnings — verify inline PR comments appear
- [ ] Enable `enable_shfmt: true` in a consumer repo with unformatted shell scripts — verify inline suggestions appear
- [ ] Verify harden-runner in `audit` mode logs only the 4 expected endpoints for these jobs
- [ ] Verify both jobs are skipped when inputs remain `false` (default)