### PR TITLE
feat: add shellcheck and shfmt linters to lint.yml via reviewdog

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,7 +4,7 @@ name: Lint
 # Usage: uses: trowaflo/github-actions/.github/workflows/lint.yml@<sha>
 #
 # Defaults on : actionlint = true (opt-out)
-# Defaults opt-in : markdown, yaml, ansible, terraform, json = false
+# Defaults opt-in : markdown, yaml, ansible, terraform, json, shellcheck, shfmt = false
 
 on:
   workflow_call:
@@ -28,6 +28,14 @@ on:
 
       enable_markdown_lint:
         description: "Lint Markdown with markdownlint-cli2"
+        type: boolean
+        default: false
+      enable_shellcheck:
+        description: "Lint shell scripts (bash/sh/zsh) with shellcheck via reviewdog (inline PR comments)"
+        type: boolean
+        default: false
+      enable_shfmt:
+        description: "Check shell script formatting with shfmt via reviewdog (inline PR comments)"
         type: boolean
         default: false
       enable_terraform_validate:
@@ -343,3 +351,66 @@ jobs:
             fi
           done < <(find . -name '*.json5' -not -path './.git/*' -not -path './node_modules/*' -print0)
           exit $exit_code
+
+  shellcheck:
+    if: ${{ inputs.enable_shellcheck }}
+    name: Lint Shell (shellcheck)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    env:
+      # Built-in harden-runner allowed endpoints:
+      #   agent.api.stepsecurity.io:443 — harden-runner agent
+      #   api.github.com:443            — reviewdog posts PR review comments
+      #   github.com:443                — checkout + shellcheck + reviewdog binaries
+      #   release-assets.githubusercontent.com:443 — binary downloads
+      _HARDEN_DEFAULTS: >-
+        agent.api.stepsecurity.io:443
+        api.github.com:443
+        github.com:443
+        release-assets.githubusercontent.com:443
+    steps:
+      - name: Harden Runner
+        if: ${{ inputs.enable_harden_runner }}
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        with:
+          egress-policy: ${{ inputs.harden_runner_egress_policy }}
+          allowed-endpoints: ${{ env._HARDEN_DEFAULTS }} ${{ inputs.harden_runner_allowed_endpoints }}
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: reviewdog/action-shellcheck@4c07458293ac342d477251099501a718ae5ef86e # v1.32.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          reporter: github-pr-review
+          filter_mode: added
+
+  shfmt:
+    if: ${{ inputs.enable_shfmt }}
+    name: Format Shell (shfmt)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    env:
+      # Built-in harden-runner allowed endpoints:
+      #   agent.api.stepsecurity.io:443 — harden-runner agent
+      #   api.github.com:443            — reviewdog posts PR suggestions
+      #   github.com:443                — checkout + shfmt + reviewdog binaries
+      #   release-assets.githubusercontent.com:443 — binary downloads
+      _HARDEN_DEFAULTS: >-
+        agent.api.stepsecurity.io:443
+        api.github.com:443
+        github.com:443
+        release-assets.githubusercontent.com:443
+    steps:
+      - name: Harden Runner
+        if: ${{ inputs.enable_harden_runner }}
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        with:
+          egress-policy: ${{ inputs.harden_runner_egress_policy }}
+          allowed-endpoints: ${{ env._HARDEN_DEFAULTS }} ${{ inputs.harden_runner_allowed_endpoints }}
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: reviewdog/action-shfmt@d8f080930b9be5847b4f97e9f4122b81a82aaeac # v1.0.4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          filter_mode: added

--- a/docs/lint.md
+++ b/docs/lint.md
@@ -30,6 +30,8 @@ jobs:
 | `enable_yamllint` | boolean | `false` | Lint YAML avec yamllint |
 | `enable_json_lint` | boolean | `false` | Validation syntaxe JSON et JSON5 |
 | `enable_ansible_lint` | boolean | `false` | Lint Ansible avec ansible-lint |
+| `enable_shellcheck` | boolean | `false` | Lint scripts shell (bash/sh/zsh) avec shellcheck via reviewdog (inline PR comments) |
+| `enable_shfmt` | boolean | `false` | Vérification du formatage des scripts shell avec shfmt via reviewdog (inline PR suggestions) |
 | `enable_terraform_validate` | boolean | `false` | `terraform fmt` + `tflint` |
 
 ## Permissions requises
@@ -38,6 +40,7 @@ jobs:
 | --- | --- |
 | `contents: read` | Tous les jobs (checkout) |
 | `security-events: write` | actionlint (upload SARIF) |
+| `pull-requests: write` | shellcheck, shfmt (reviewdog inline comments) |
 
 ## Secrets
 
@@ -58,6 +61,20 @@ Valide la syntaxe de tous les fichiers `*.json` (via `json.load`) et `*.json5` (
 ### yamllint
 
 Créer un `.yamllint.yml` à la racine du repo pour surcharger la configuration par défaut.
+
+### shellcheck
+
+Analyse statique des scripts shell (bash/sh/zsh) via [`reviewdog/action-shellcheck`](https://github.com/reviewdog/action-shellcheck). Détecte les erreurs courantes et les problèmes de sécurité (variables non quotées, injections via `eval`, etc.).
+
+Résultats postés en inline review comments sur la PR. Seuls les fichiers modifiés par la PR sont analysés (`filter_mode: added`).
+
+Par défaut, scanne les fichiers `*.sh`. Pour inclure aussi les scripts sans extension mais avec un shebang, activer `check_all_files_with_shebangs` via `shellcheck_flags`.
+
+### shfmt
+
+Vérification du formatage des scripts shell via [`reviewdog/action-shfmt`](https://github.com/reviewdog/action-shfmt). Poste des suggestions de correction directement dans la PR (inline suggestions applicables en un clic).
+
+Par défaut : indentation 2 espaces, `case` indenté (`-i 2 -ci`). Configurable via l'input `shfmt_flags` si nécessaire.
 
 ### harden-runner
 


### PR DESCRIPTION
## Summary

- Adds `enable_shellcheck` (opt-in, default `false`) — lints bash/sh/zsh scripts with `reviewdog/action-shellcheck` v1.32.0, posts inline review comments on PRs
- Adds `enable_shfmt` (opt-in, default `false`) — checks shell script formatting with `reviewdog/action-shfmt` v1.0.4, posts inline suggestions applicable in one click
- Both jobs use a minimal `_HARDEN_DEFAULTS` (4 endpoints) instead of the full shared list — only what reviewdog actually needs
- Requires `pull-requests: write` on consumer side when either is enabled

## Test plan

- [ ] Enable `enable_shellcheck: true` in a consumer repo with `.sh` files containing shellcheck warnings — verify inline PR comments appear
- [ ] Enable `enable_shfmt: true` in a consumer repo with unformatted shell scripts — verify inline suggestions appear
- [ ] Verify harden-runner in `audit` mode logs only the 4 expected endpoints for these jobs
- [ ] Verify both jobs are skipped when inputs remain `false` (default)