### PR TITLE
fix: use github-actions[bot] identity in helm publish workflows

### DIFF
--- a/.github/workflows/ci-helm-cleanup.yml
+++ b/.github/workflows/ci-helm-cleanup.yml
@@ -75,8 +75,8 @@ jobs:
       - name: Configure Git
         if: steps.check.outputs.exists == 'true'
         run: |
-          git config user.name "$GITHUB_ACTOR"
-          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
       - name: Remove PR charts and update index
         if: steps.check.outputs.exists == 'true'
         env:

--- a/.github/workflows/ci-helm.yml
+++ b/.github/workflows/ci-helm.yml
@@ -528,8 +528,8 @@ jobs:
       - uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
       - name: Configure Git
         run: |
-          git config user.name "$GITHUB_ACTOR"
-          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
       - name: Install yq with checksum verification
         run: |
           set -euo pipefail

--- a/.github/workflows/release-helm.yml
+++ b/.github/workflows/release-helm.yml
@@ -76,8 +76,8 @@ jobs:
       - uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
       - name: Configure Git
         run: |
-          git config user.name "$GITHUB_ACTOR"
-          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
       - name: Determine release directories
         id: dirs
         env:


### PR DESCRIPTION
Aligns the Configure Git step in 3 helm-publish jobs on the bot identity already used by helm-bump and helm-docs in ci-helm.yml.

Before: commits to pr-charts (helm-pr-charts), gh-pages (release-helm), and PR cleanup were attributed to $GITHUB_ACTOR (the PR author), polluting personal contribution history and blurring automation provenance.

After: all three jobs use github-actions[bot]@users.noreply.github.com — consistent with helm-bump and helm-docs.

Files:
- .github/workflows/ci-helm.yml — job helm-pr-charts
- .github/workflows/ci-helm-cleanup.yml
- .github/workflows/release-helm.yml

No input/output changes — internal identity fix only.