### PR TITLE
fix(ci-helm-cleanup): reconcile orphan PR charts on every run

### DIFF
--- a/.github/workflows/ci-helm-cleanup.yml
+++ b/.github/workflows/ci-helm-cleanup.yml
@@ -77,17 +77,45 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-      - name: Remove PR charts and update index
+      - name: Reconcile orphan PR charts and update index
         if: steps.check.outputs.exists == 'true'
         env:
-          PR_NUM: "${{ github.event.pull_request.number }}"
           REPO: "${{ github.repository }}"
+          GH_TOKEN: "${{ github.token }}"
         run: |
-          rm -f ./*-pr"${PR_NUM}".tgz || true
+          set -euo pipefail
+          shopt -s nullglob
+          tgz_files=( ./*.tgz )
+          if [ ${#tgz_files[@]} -eq 0 ]; then
+            echo "No PR charts present, nothing to reconcile."
+            exit 0
+          fi
+          pr_nums=$(printf '%s\n' "${tgz_files[@]}" | grep -oE 'pr[0-9]+\.tgz$' | sed 's/pr//;s/\.tgz//' | sort -un || true)
+          removed=0
+          for pr in $pr_nums; do
+            state=$(gh api "repos/${REPO}/pulls/${pr}" --jq '.state' 2>/dev/null || echo "unknown")
+            if [ "$state" = "closed" ]; then
+              echo "PR #${pr} is closed → removing artifacts"
+              rm -f -- ./*-pr"${pr}".tgz
+              removed=$((removed + 1))
+            elif [ "$state" = "open" ]; then
+              echo "PR #${pr} is open → keeping artifacts"
+            else
+              echo "PR #${pr} state unknown → keeping artifacts (safe default)"
+            fi
+          done
+          if [ "$removed" -eq 0 ]; then
+            echo "No orphans to remove."
+            exit 0
+          fi
           helm repo index . --url "https://raw.githubusercontent.com/${REPO}/pr-charts"
           git add -A
-          git commit -m "Remove PR #${PR_NUM} charts after merge/close" || echo "No charts to remove"
-          git push origin pr-charts || echo "Nothing to push"
+          if git diff --cached --quiet; then
+            echo "No changes staged after index regeneration."
+            exit 0
+          fi
+          git commit -m "chore: clean up charts for ${removed} closed PR(s)"
+          git push origin pr-charts
       - name: Comment on merged PR
         if: steps.check.outputs.exists == 'true' && github.event.pull_request.merged == true
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0

--- a/docs/helm.md
+++ b/docs/helm.md
@@ -91,6 +91,12 @@ Supprime les charts PR de la branche `pr-charts` quand une PR est mergée ou fer
 
 Pas de flag — appeler ce workflow implique l'intention de cleanup.
 
+**Réconciliation auto** : à chaque exécution, le workflow scanne tous les `*-pr<N>.tgz`
+présents sur la branche et supprime ceux dont le PR est `closed` (mergé ou non),
+pas seulement le PR courant. Cela rattrape automatiquement les orphelins issus
+de runs précédents qui auraient échoué (ex. egress block, runner indisponible).
+La branche est uniquement modifiée si au moins un orphelin a été retiré.
+
 ### Usage
 
 ```yaml


### PR DESCRIPTION
## Context

Empirically observed on `trowaflo/helm-charts/pr-charts`: 47 orphan `.tgz` files for already-closed PRs (#182, #184, #211, #228, #232, #235). Cause analysis on the failing cleanup runs shows past harden-runner egress blocking (notably `get.helm.sh` not yet in defaults), runner crashes, etc. — once a cleanup run fails, no future run rescues the orphans.

## Fix

The cleanup step now reconciles **all** PR markers present on the `pr-charts` branch on every run:

- List every `*-pr<N>.tgz` present
- Query `gh api repos/<owner>/<repo>/pulls/<N>` per marker
- Remove artifacts whose PR is `closed` (merged or not)
- Regenerate index only if at least one orphan was removed
- Skip commit if `git diff --cached` is empty (no more no-op commits)

Self-healing: if a run fails (egress block, runner crash), the next one rescues.

## Notes

- One-shot manual cleanup of the existing 47 orphans on `trowaflo/helm-charts` already pushed (commit `chore: clean up orphan PR charts`).
- No new inputs, no breaking changes for consumers.
- Uses `gh` CLI pre-installed on GitHub-hosted runners + `api.github.com:443` already in harden-runner defaults.
- `docs/helm.md` updated with the reconciliation note.

## Future work (not in this PR)

OCI/GHCR migration evaluated as a longer-term replacement for the orphan-branch pattern (see vault note `wiki/topics/helm-chart-previews.md`).