### PR TITLE
feat(ci-helm): dual-publish PR charts to branch and OCI/GHCR

### DIFF
--- a/.github/workflows/ci-helm-cleanup.yml
+++ b/.github/workflows/ci-helm-cleanup.yml
@@ -134,12 +134,19 @@ jobs:
         if: ${{ inputs.enable_oci_cleanup }}
         env:
           REPO: "${{ github.repository }}"
-          GH_TOKEN: "${{ secrets.OCI_CLEANUP_TOKEN || github.token }}"
+          # Repo/PR reads always go through github.token (full repo:read scope).
+          # OCI_CLEANUP_TOKEN may be a PAT scoped only to delete:packages and
+          # would fail on /repos and /pulls reads, so we use it ONLY on DELETE.
+          GH_TOKEN: "${{ github.token }}"
+          DELETE_TOKEN: "${{ secrets.OCI_CLEANUP_TOKEN || github.token }}"
         run: |
           set -euo pipefail
           owner="${REPO%%/*}"
           owner_lc=$(echo "$owner" | tr '[:upper:]' '[:lower:]')
-          owner_type=$(gh api "/repos/${REPO}" --jq '.owner.type')
+          if ! owner_type=$(gh api "/repos/${REPO}" --jq '.owner.type' 2>/dev/null); then
+            echo "::warning::Failed to fetch owner type for ${REPO}. Skipping OCI cleanup (best-effort)."
+            exit 0
+          fi
           if [ "$owner_type" != "User" ]; then
             echo "::warning::OCI cleanup is only implemented for user-owned repositories (got owner_type=${owner_type}). Skipping to avoid touching organization packages."
             exit 0
@@ -161,7 +168,7 @@ jobs:
                 state=$(gh api "/repos/${REPO}/pulls/${pr_num}" --jq '.state' 2>/dev/null || echo "unknown")
                 if [ "$state" = "closed" ]; then
                   echo "Deleting ${pkg}:${tag} (PR #${pr_num} closed)"
-                  if gh api --method DELETE "${delete_base}/container/${pkg}/versions/${vid}" 2>&1; then
+                  if GH_TOKEN="$DELETE_TOKEN" gh api --method DELETE "${delete_base}/container/${pkg}/versions/${vid}" 2>&1; then
                     orphans=$((orphans + 1))
                   else
                     echo "::warning::Failed to delete ${pkg}:${tag} — a PAT with delete:packages scope is required (secrets.OCI_CLEANUP_TOKEN)"

--- a/.github/workflows/ci-helm-cleanup.yml
+++ b/.github/workflows/ci-helm-cleanup.yml
@@ -175,11 +175,17 @@ jobs:
       - name: Comment on merged PR
         if: steps.check.outputs.exists == 'true' && github.event.pull_request.merged == true
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        env:
+          OCI_ENABLED: ${{ inputs.enable_oci_cleanup }}
         with:
           script: |
+            const ociEnabled = process.env.OCI_ENABLED === 'true';
+            const targets = ociEnabled
+              ? 'the `pr-charts` branch and the GHCR OCI registry'
+              : 'the `pr-charts` branch';
             await github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: '## PR Charts Cleaned Up\n\nThe test charts for this PR have been removed from the `pr-charts` branch.'
+              body: `## PR Charts Cleaned Up\n\nThe test charts for this PR have been removed from ${targets}.`
             });

--- a/.github/workflows/ci-helm-cleanup.yml
+++ b/.github/workflows/ci-helm-cleanup.yml
@@ -143,6 +143,8 @@ jobs:
           set -euo pipefail
           owner="${REPO%%/*}"
           owner_lc=$(echo "$owner" | tr '[:upper:]' '[:lower:]')
+          repo_name_lc=$(echo "${REPO#*/}" | tr '[:upper:]' '[:lower:]')
+          prefix="${repo_name_lc}/"
           if ! owner_type=$(gh api "/repos/${REPO}" --jq '.owner.type' 2>/dev/null); then
             echo "::warning::Failed to fetch owner type for ${REPO}. Skipping OCI cleanup (best-effort)."
             exit 0
@@ -153,13 +155,20 @@ jobs:
           fi
           list_base="/users/${owner_lc}/packages"
           delete_base="/user/packages"
-          packages=$(gh api "${list_base}?package_type=container&per_page=100" --paginate --jq '.[].name' 2>/dev/null || true)
+          # Only consider packages whose name starts with "<repo>/" — packages produced
+          # by ci-helm.yml use the path oci://ghcr.io/<owner>/<repo>/<chart>, so they
+          # land in GHCR as "<repo>/<chart>". This prevents touching versions that
+          # belong to other repos under the same owner.
+          packages=$(gh api "${list_base}?package_type=container&per_page=100" --paginate \
+            --jq ".[] | select(.name | startswith(\"${prefix}\")) | .name" 2>/dev/null || true)
           if [ -z "$packages" ]; then
-            echo "No container packages for ${owner_lc}, nothing to reconcile."
+            echo "No container packages under ${owner_lc}/${prefix}*, nothing to reconcile."
             exit 0
           fi
           orphans=0
           for pkg in $packages; do
+            # Package names contain "/", which must be URL-encoded in API paths.
+            encoded_pkg=$(printf '%s' "$pkg" | sed 's|/|%2F|g')
             while IFS=$'\t' read -r vid tags; do
               [ -z "$vid" ] && continue
               for tag in $tags; do
@@ -168,7 +177,7 @@ jobs:
                 state=$(gh api "/repos/${REPO}/pulls/${pr_num}" --jq '.state' 2>/dev/null || echo "unknown")
                 if [ "$state" = "closed" ]; then
                   echo "Deleting ${pkg}:${tag} (PR #${pr_num} closed)"
-                  if GH_TOKEN="$DELETE_TOKEN" gh api --method DELETE "${delete_base}/container/${pkg}/versions/${vid}" 2>&1; then
+                  if GH_TOKEN="$DELETE_TOKEN" gh api --method DELETE "${delete_base}/container/${encoded_pkg}/versions/${vid}" 2>&1; then
                     orphans=$((orphans + 1))
                   else
                     echo "::warning::Failed to delete ${pkg}:${tag} — a PAT with delete:packages scope is required (secrets.OCI_CLEANUP_TOKEN)"
@@ -176,7 +185,7 @@ jobs:
                   break
                 fi
               done
-            done < <(gh api "${list_base}/container/${pkg}/versions?per_page=100" --paginate --jq '.[] | "\(.id)\t\(.metadata.container.tags // [] | join(" "))"' 2>/dev/null || true)
+            done < <(gh api "${list_base}/container/${encoded_pkg}/versions?per_page=100" --paginate --jq '.[] | "\(.id)\t\(.metadata.container.tags // [] | join(" "))"' 2>/dev/null || true)
           done
           echo "Removed ${orphans} OCI version(s)."
       - name: Comment on merged PR

--- a/.github/workflows/ci-helm-cleanup.yml
+++ b/.github/workflows/ci-helm-cleanup.yml
@@ -12,6 +12,13 @@ on:
         description: "Runtime security via StepSecurity harden-runner"
         type: boolean
         default: true
+      enable_oci_cleanup:
+        description: >-
+          Also delete OCI package versions tagged *-pr<N> from GHCR for closed PRs.
+          For user-owned repos, the GITHUB_TOKEN cannot delete user packages —
+          provide a PAT with delete:packages scope via secrets.OCI_CLEANUP_TOKEN.
+        type: boolean
+        default: false
       harden_runner_allowed_endpoints:
         description: "Extra endpoints to allow (merged with built-in defaults, space-separated)"
         type: string
@@ -24,6 +31,10 @@ on:
         description: "Skip event.action == closed check (for testing only)"
         type: boolean
         default: false
+    secrets:
+      OCI_CLEANUP_TOKEN:
+        description: "Optional PAT with delete:packages scope (required for user-owned repos when enable_oci_cleanup is true)"
+        required: false
 
 permissions: {}
 
@@ -34,18 +45,21 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      packages: write
       pull-requests: write
     env:
       # Built-in harden-runner allowed endpoints:
       #   agent.api.stepsecurity.io:443 — harden-runner agent
       #   api.github.com:443 — GitHub API (PR chart cleanup via github-script)
       #   get.helm.sh:443 — Helm binary (azure/setup-helm)
+      #   ghcr.io:443 — OCI registry (only when enable_oci_cleanup is true)
       #   github.com:443 — git clone, actions checkout
       _HARDEN_DEFAULTS: >-
         agent.api.stepsecurity.io:443
         github.com:443
         api.github.com:443
         get.helm.sh:443
+        ghcr.io:443
     steps:
       - name: Harden Runner
         if: ${{ inputs.enable_harden_runner }}
@@ -116,6 +130,49 @@ jobs:
           fi
           git commit -m "chore: clean up charts for ${removed} closed PR(s)"
           git push origin pr-charts
+      - name: Reconcile orphan OCI package versions (GHCR)
+        if: ${{ inputs.enable_oci_cleanup }}
+        env:
+          REPO: "${{ github.repository }}"
+          GH_TOKEN: "${{ secrets.OCI_CLEANUP_TOKEN || github.token }}"
+        run: |
+          set -euo pipefail
+          owner="${REPO%%/*}"
+          owner_lc=$(echo "$owner" | tr '[:upper:]' '[:lower:]')
+          owner_type=$(gh api "/repos/${REPO}" --jq '.owner.type')
+          if [ "$owner_type" = "Organization" ]; then
+            list_base="/orgs/${owner_lc}/packages"
+            delete_base="/orgs/${owner_lc}/packages"
+          else
+            list_base="/users/${owner_lc}/packages"
+            delete_base="/user/packages"
+          fi
+          packages=$(gh api "${list_base}?package_type=container&per_page=100" --paginate --jq '.[].name' 2>/dev/null || true)
+          if [ -z "$packages" ]; then
+            echo "No container packages for ${owner_lc}, nothing to reconcile."
+            exit 0
+          fi
+          orphans=0
+          for pkg in $packages; do
+            while IFS=$'\t' read -r vid tags; do
+              [ -z "$vid" ] && continue
+              for tag in $tags; do
+                pr_num=$(echo "$tag" | grep -oE 'pr[0-9]+$' | sed 's/pr//' || true)
+                [ -z "$pr_num" ] && continue
+                state=$(gh api "/repos/${REPO}/pulls/${pr_num}" --jq '.state' 2>/dev/null || echo "unknown")
+                if [ "$state" = "closed" ]; then
+                  echo "Deleting ${pkg}:${tag} (PR #${pr_num} closed)"
+                  if gh api --method DELETE "${delete_base}/container/${pkg}/versions/${vid}" 2>&1; then
+                    orphans=$((orphans + 1))
+                  else
+                    echo "::warning::Failed to delete ${pkg}:${tag} — for user-owned repos a PAT with delete:packages scope is required (secrets.OCI_CLEANUP_TOKEN)"
+                  fi
+                  break
+                fi
+              done
+            done < <(gh api "${list_base}/container/${pkg}/versions?per_page=100" --paginate --jq '.[] | "\(.id)\t\(.metadata.container.tags // [] | join(" "))"' 2>/dev/null || true)
+          done
+          echo "Removed ${orphans} OCI version(s)."
       - name: Comment on merged PR
         if: steps.check.outputs.exists == 'true' && github.event.pull_request.merged == true
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0

--- a/.github/workflows/ci-helm-cleanup.yml
+++ b/.github/workflows/ci-helm-cleanup.yml
@@ -140,13 +140,12 @@ jobs:
           owner="${REPO%%/*}"
           owner_lc=$(echo "$owner" | tr '[:upper:]' '[:lower:]')
           owner_type=$(gh api "/repos/${REPO}" --jq '.owner.type')
-          if [ "$owner_type" = "Organization" ]; then
-            list_base="/orgs/${owner_lc}/packages"
-            delete_base="/orgs/${owner_lc}/packages"
-          else
-            list_base="/users/${owner_lc}/packages"
-            delete_base="/user/packages"
+          if [ "$owner_type" != "User" ]; then
+            echo "::warning::OCI cleanup is only implemented for user-owned repositories (got owner_type=${owner_type}). Skipping to avoid touching organization packages."
+            exit 0
           fi
+          list_base="/users/${owner_lc}/packages"
+          delete_base="/user/packages"
           packages=$(gh api "${list_base}?package_type=container&per_page=100" --paginate --jq '.[].name' 2>/dev/null || true)
           if [ -z "$packages" ]; then
             echo "No container packages for ${owner_lc}, nothing to reconcile."
@@ -165,7 +164,7 @@ jobs:
                   if gh api --method DELETE "${delete_base}/container/${pkg}/versions/${vid}" 2>&1; then
                     orphans=$((orphans + 1))
                   else
-                    echo "::warning::Failed to delete ${pkg}:${tag} — for user-owned repos a PAT with delete:packages scope is required (secrets.OCI_CLEANUP_TOKEN)"
+                    echo "::warning::Failed to delete ${pkg}:${tag} — a PAT with delete:packages scope is required (secrets.OCI_CLEANUP_TOKEN)"
                   fi
                   break
                 fi

--- a/.github/workflows/ci-helm.yml
+++ b/.github/workflows/ci-helm.yml
@@ -45,8 +45,9 @@ on:
       enable_oci_pr_charts:
         description: >-
           Additionally publish PR chart packages to GHCR OCI registry
-          (oci://ghcr.io/<owner>/<chart>). Independent of enable_pr_charts —
-          enable both to dual-publish during the migration period.
+          (oci://ghcr.io/<owner>/<repo>/<chart>). The repo namespace prevents
+          collisions across repos under the same owner. Independent of
+          enable_pr_charts — enable both to dual-publish during the migration period.
         type: boolean
         default: false
       enable_unittest:

--- a/.github/workflows/ci-helm.yml
+++ b/.github/workflows/ci-helm.yml
@@ -652,11 +652,12 @@ jobs:
         if: ${{ inputs.enable_oci_pr_charts && steps.package.outputs.packaged != '' }}
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          ACTOR: ${{ github.actor }}
           OWNER: ${{ github.repository_owner }}
         run: |
           set -euo pipefail
           owner_lc=$(echo "$OWNER" | tr '[:upper:]' '[:lower:]')
-          echo "$GITHUB_TOKEN" | helm registry login ghcr.io --username "$OWNER" --password-stdin
+          echo "$GITHUB_TOKEN" | helm registry login ghcr.io --username "$ACTOR" --password-stdin
           trap 'helm registry logout ghcr.io >/dev/null 2>&1 || true' EXIT
           for tgz in /tmp/pr-charts/*.tgz; do
             [ -f "$tgz" ] || continue

--- a/.github/workflows/ci-helm.yml
+++ b/.github/workflows/ci-helm.yml
@@ -654,15 +654,18 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
           ACTOR: ${{ github.actor }}
           OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
           owner_lc=$(echo "$OWNER" | tr '[:upper:]' '[:lower:]')
+          repo_name_lc=$(echo "${REPO#*/}" | tr '[:upper:]' '[:lower:]')
+          target="oci://ghcr.io/${owner_lc}/${repo_name_lc}"
           echo "$GITHUB_TOKEN" | helm registry login ghcr.io --username "$ACTOR" --password-stdin
           trap 'helm registry logout ghcr.io >/dev/null 2>&1 || true' EXIT
           for tgz in /tmp/pr-charts/*.tgz; do
             [ -f "$tgz" ] || continue
-            echo "Pushing $(basename "$tgz") → oci://ghcr.io/${owner_lc}"
-            helm push "$tgz" "oci://ghcr.io/${owner_lc}"
+            echo "Pushing $(basename "$tgz") → ${target}"
+            helm push "$tgz" "${target}"
           done
       - name: Comment on PR
         if: steps.package.outputs.packaged != ''
@@ -679,6 +682,7 @@ jobs:
             const enableBranch = process.env.ENABLE_BRANCH === 'true';
             const enableOci = process.env.ENABLE_OCI === 'true';
             const ownerLc = process.env.OWNER.toLowerCase();
+            const repoNameLc = process.env.REPO_FULL.split('/')[1].toLowerCase();
             let chartsList = '';
             packaged.forEach(item => {
               if (item) {
@@ -702,7 +706,7 @@ jobs:
               sections.push(
                 '### Install via OCI registry (GHCR)\n',
                 '```bash',
-                `helm install test-release oci://ghcr.io/${ownerLc}/<chart-name> --version <version>`,
+                `helm install test-release oci://ghcr.io/${ownerLc}/${repoNameLc}/<chart-name> --version <version>`,
                 '```\n'
               );
             }

--- a/.github/workflows/ci-helm.yml
+++ b/.github/workflows/ci-helm.yml
@@ -42,6 +42,13 @@ on:
         description: "Package modified charts on PR and publish to pr-charts branch"
         type: boolean
         default: false
+      enable_oci_pr_charts:
+        description: >-
+          Additionally publish PR chart packages to GHCR OCI registry
+          (oci://ghcr.io/<owner>/<chart>). Independent of enable_pr_charts —
+          enable both to dual-publish during the migration period.
+        type: boolean
+        default: false
       enable_unittest:
         description: "Helm unit tests with helm-unittest (matrix per chart)"
         type: boolean
@@ -492,20 +499,22 @@ jobs:
   helm-pr-charts:
     needs: [helm-bump]
     if: >-
-      ${{ inputs.enable_pr_charts &&
+      ${{ (inputs.enable_pr_charts || inputs.enable_oci_pr_charts) &&
           github.event_name == 'pull_request' &&
           (needs.helm-bump.result == 'success' || needs.helm-bump.result == 'skipped') }}
     name: PR Chart Packages
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      packages: write
       pull-requests: write
     env:
-      # Built-in endpoints — see first job above
+      # Built-in endpoints — see first job above; adds ghcr.io for OCI publish
       _HARDEN_DEFAULTS: >-
         agent.api.stepsecurity.io:443
         github.com:443
         api.github.com:443
+        ghcr.io:443
         release-assets.githubusercontent.com:443
         registry.npmjs.org:443
         objects.githubusercontent.com:443
@@ -617,7 +626,7 @@ jobs:
           path: /tmp/pr-artifacts/*.tgz
           retention-days: 30
       - name: Publish to pr-charts branch
-        if: steps.package.outputs.packaged != ''
+        if: ${{ inputs.enable_pr_charts && steps.package.outputs.packaged != '' }}
         env:
           PR_NUM: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
@@ -639,15 +648,36 @@ jobs:
           git add ./*.tgz index.yaml
           git commit -m "Add PR #${PR_NUM} charts" || echo "No changes to commit"
           git push origin pr-charts
+      - name: Publish to OCI registry (GHCR)
+        if: ${{ inputs.enable_oci_pr_charts && steps.package.outputs.packaged != '' }}
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          OWNER: ${{ github.repository_owner }}
+        run: |
+          set -euo pipefail
+          owner_lc=$(echo "$OWNER" | tr '[:upper:]' '[:lower:]')
+          echo "$GITHUB_TOKEN" | helm registry login ghcr.io --username "$OWNER" --password-stdin
+          trap 'helm registry logout ghcr.io >/dev/null 2>&1 || true' EXIT
+          for tgz in /tmp/pr-charts/*.tgz; do
+            [ -f "$tgz" ] || continue
+            echo "Pushing $(basename "$tgz") → oci://ghcr.io/${owner_lc}"
+            helm push "$tgz" "oci://ghcr.io/${owner_lc}"
+          done
       - name: Comment on PR
         if: steps.package.outputs.packaged != ''
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         env:
           PACKAGED: ${{ steps.package.outputs.packaged }}
           REPO_FULL: ${{ github.repository }}
+          OWNER: ${{ github.repository_owner }}
+          ENABLE_BRANCH: ${{ inputs.enable_pr_charts }}
+          ENABLE_OCI: ${{ inputs.enable_oci_pr_charts }}
         with:
           script: |
             const packaged = process.env.PACKAGED.trim().split(' ');
+            const enableBranch = process.env.ENABLE_BRANCH === 'true';
+            const enableOci = process.env.ENABLE_OCI === 'true';
+            const ownerLc = process.env.OWNER.toLowerCase();
             let chartsList = '';
             packaged.forEach(item => {
               if (item) {
@@ -655,18 +685,28 @@ jobs:
                 chartsList += `- \`${name}\` version \`${version}\`\n`;
               }
             });
-            const repoUrl = `https://raw.githubusercontent.com/${process.env.REPO_FULL}/pr-charts`;
-            const body = [
-              '## PR Charts Available for Testing\n',
-              chartsList,
-              '### Testing with Helm\n',
-              '```bash',
-              `helm repo add pr-charts ${repoUrl}`,
-              'helm repo update',
-              'helm install test-release pr-charts/<chart-name> --version <version>',
-              '```\n',
-              '> Charts are automatically removed when this PR is merged or closed.'
-            ].join('\n');
+            const sections = ['## PR Charts Available for Testing\n', chartsList];
+            if (enableBranch) {
+              const repoUrl = `https://raw.githubusercontent.com/${process.env.REPO_FULL}/pr-charts`;
+              sections.push(
+                '### Install via Helm repository (branch `pr-charts`)\n',
+                '```bash',
+                `helm repo add pr-charts ${repoUrl}`,
+                'helm repo update',
+                'helm install test-release pr-charts/<chart-name> --version <version>',
+                '```\n'
+              );
+            }
+            if (enableOci) {
+              sections.push(
+                '### Install via OCI registry (GHCR)\n',
+                '```bash',
+                `helm install test-release oci://ghcr.io/${ownerLc}/<chart-name> --version <version>`,
+                '```\n'
+              );
+            }
+            sections.push('> Charts are automatically removed when this PR is merged or closed.');
+            const body = sections.join('\n');
             const comments = await github.rest.issues.listComments({
               issue_number: context.issue.number,
               owner: context.repo.owner,

--- a/.github/workflows/test-helm.yml
+++ b/.github/workflows/test-helm.yml
@@ -51,11 +51,13 @@ jobs:
       contents: write
       pull-requests: write
     # Note: enable_oci_cleanup is intentionally NOT enabled here.
-    # The reconciliation step lists every container package of the owner without
-    # filtering by source repo (GHCR has no strict repo->package binding), so
-    # enabling it under the github-actions test repo could scan/delete versions
-    # belonging to other repos under the same owner (e.g. trowaflo/helm-charts).
-    # The pilot in trowaflo/helm-charts#238 covers the cleanup path end-to-end.
+    # Even though the cleanup step filters by the "<repo>/" GHCR namespace prefix
+    # (so it would only target packages produced by this repo's helm-pr-charts),
+    # exercising it from test-helm.yml means every test PR on github-actions
+    # would issue real DELETE calls against GHCR for any "<repo>/<chart>" version
+    # whose tag matches a closed PR. We prefer to cover the cleanup path
+    # end-to-end via the pilot in trowaflo/helm-charts#238 where the namespace
+    # is dedicated to a real Helm repo.
     with:
       skip_event_check: true
       harden_runner_egress_policy: block

--- a/.github/workflows/test-helm.yml
+++ b/.github/workflows/test-helm.yml
@@ -20,6 +20,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      packages: write
       checks: write
     with:
       enable_lint: true
@@ -28,6 +29,7 @@ jobs:
       enable_docs: true
       enable_docs_check: true
       enable_pr_charts: true
+      enable_oci_pr_charts: true
       charts_dir: tests/charts
       harden_runner_egress_policy: block
 
@@ -48,6 +50,12 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+    # Note: enable_oci_cleanup is intentionally NOT enabled here.
+    # The reconciliation step lists every container package of the owner without
+    # filtering by source repo (GHCR has no strict repo->package binding), so
+    # enabling it under the github-actions test repo could scan/delete versions
+    # belonging to other repos under the same owner (e.g. trowaflo/helm-charts).
+    # The pilot in trowaflo/helm-charts#238 covers the cleanup path end-to-end.
     with:
       skip_event_check: true
       harden_runner_egress_policy: block

--- a/docs/helm.md
+++ b/docs/helm.md
@@ -130,9 +130,11 @@ jobs:
 | `harden_runner_allowed_endpoints` | string | (built-in) | Extra endpoints merged with defaults |
 | `enable_oci_cleanup` | boolean | `false` | Supprime aussi les versions OCI taguées `*-pr<N>` sur GHCR pour les PRs closed |
 
-### OCI cleanup et permissions
+### OCI cleanup — limité aux repos user-owned
 
-Pour les **org-owned repos** : `GITHUB_TOKEN` avec `packages: write` suffit pour delete.
+Le step ne traite **que** les comptes user-owned. Si l'owner est une Organization, le step
+émet un `::warning::` et skip — pour ne pas toucher de packages d'orgs avec un workflow
+qui n'a été validé que sur du user-owned.
 
 Pour les **user-owned repos** : l'API `/user/packages/...` requiert un PAT avec scope `delete:packages`.
 Fournir le PAT via `secrets.OCI_CLEANUP_TOKEN` :

--- a/docs/helm.md
+++ b/docs/helm.md
@@ -50,9 +50,22 @@ jobs:
 | `enable_bump` | boolean | `false` | Auto-bump de version des charts modifiés sur PR |
 | `enable_docs` | boolean | `false` | Génération doc avec helm-docs (après bump) |
 | `enable_docs_check` | boolean | `false` | Valide que les docs sont à jour |
-| `enable_pr_charts` | boolean | `false` | Package les charts modifiés et poste un commentaire |
+| `enable_pr_charts` | boolean | `false` | Package les charts modifiés et publie sur la branche `pr-charts` |
+| `enable_oci_pr_charts` | boolean | `false` | Publie aussi sur GHCR OCI (`oci://ghcr.io/<owner>/<chart>`). Indépendant de `enable_pr_charts` — activer les deux pour dual-publish |
 | `charts_dir` | string | `"charts"` | Répertoire racine des charts |
 | `bump_skip_actors` | string | `"renovate[bot]"` | Acteurs à ignorer pour le bump |
+
+### Permissions requises pour `enable_oci_pr_charts`
+
+Le job déclare déjà `packages: write`. Côté consumer, ajouter :
+
+```yaml
+permissions:
+  contents: write
+  packages: write       # publication OCI sur GHCR
+  pull-requests: write
+  checks: write
+```
 
 ---
 
@@ -115,9 +128,35 @@ jobs:
 | `enable_harden_runner` | boolean | `true` | Runtime security via StepSecurity harden-runner |
 | `harden_runner_egress_policy` | string | `"audit"` | Egress policy: `audit` or `block` |
 | `harden_runner_allowed_endpoints` | string | (built-in) | Extra endpoints merged with defaults |
+| `enable_oci_cleanup` | boolean | `false` | Supprime aussi les versions OCI taguées `*-pr<N>` sur GHCR pour les PRs closed |
+
+### OCI cleanup et permissions
+
+Pour les **org-owned repos** : `GITHUB_TOKEN` avec `packages: write` suffit pour delete.
+
+Pour les **user-owned repos** : l'API `/user/packages/...` requiert un PAT avec scope `delete:packages`.
+Fournir le PAT via `secrets.OCI_CLEANUP_TOKEN` :
+
+```yaml
+jobs:
+  helm-pr-cleanup:
+    uses: trowaflo/github-actions/.github/workflows/ci-helm-cleanup.yml@<sha>
+    permissions:
+      contents: write
+      packages: write
+      pull-requests: write
+    with:
+      enable_oci_cleanup: true
+    secrets:
+      OCI_CLEANUP_TOKEN: ${{ secrets.GHCR_DELETE_PAT }}
+```
+
+Sans PAT sur un user-owned repo, le step émet un `::warning::` mais ne casse pas le workflow.
 
 ---
 
 ## Secrets
 
-Aucun — utilise `GITHUB_TOKEN` pour toutes les opérations.
+| Secret | Workflow | Required | Description |
+| --- | --- | --- | --- |
+| `OCI_CLEANUP_TOKEN` | `ci-helm-cleanup.yml` | Optional | PAT avec `delete:packages` — uniquement requis pour user-owned repos quand `enable_oci_cleanup: true` |

--- a/docs/helm.md
+++ b/docs/helm.md
@@ -51,7 +51,7 @@ jobs:
 | `enable_docs` | boolean | `false` | Génération doc avec helm-docs (après bump) |
 | `enable_docs_check` | boolean | `false` | Valide que les docs sont à jour |
 | `enable_pr_charts` | boolean | `false` | Package les charts modifiés et publie sur la branche `pr-charts` |
-| `enable_oci_pr_charts` | boolean | `false` | Publie aussi sur GHCR OCI (`oci://ghcr.io/<owner>/<chart>`). Indépendant de `enable_pr_charts` — activer les deux pour dual-publish |
+| `enable_oci_pr_charts` | boolean | `false` | Publie aussi sur GHCR OCI (`oci://ghcr.io/<owner>/<repo>/<chart>`). Indépendant de `enable_pr_charts` — activer les deux pour dual-publish |
 | `charts_dir` | string | `"charts"` | Répertoire racine des charts |
 | `bump_skip_actors` | string | `"renovate[bot]"` | Acteurs à ignorer pour le bump |
 
@@ -130,11 +130,22 @@ jobs:
 | `harden_runner_allowed_endpoints` | string | (built-in) | Extra endpoints merged with defaults |
 | `enable_oci_cleanup` | boolean | `false` | Supprime aussi les versions OCI taguées `*-pr<N>` sur GHCR pour les PRs closed |
 
-### OCI cleanup — limité aux repos user-owned
+### OCI cleanup — limité aux repos user-owned et scopé par repo
 
-Le step ne traite **que** les comptes user-owned. Si l'owner est une Organization, le step
-émet un `::warning::` et skip — pour ne pas toucher de packages d'orgs avec un workflow
-qui n'a été validé que sur du user-owned.
+**Limite owner** : le step ne traite **que** les comptes user-owned. Si l'owner est une
+Organization, le step émet un `::warning::` et skip — pour ne pas toucher de packages
+d'orgs avec un workflow qui n'a été validé que sur du user-owned.
+
+**Limite scope (lié au format de publication)** : le job `helm-pr-charts` publie en
+`oci://ghcr.io/<owner>/<repo>/<chart>`, ce qui crée des packages GHCR nommés
+`<repo>/<chart>`. Le cleanup filtre **strictement** sur le préfixe `<repo>/` du repo
+courant — il ne touche jamais aux packages d'un autre repo du même owner, même si un
+chart d'un autre repo a un tag `*-pr<N>` qui collide avec un PR fermé du repo courant.
+
+> ⚠️ Si tu as historiquement publié des charts en `oci://ghcr.io/<owner>/<chart>` (sans
+> namespace repo), ces packages legacy ne seront **pas** matchés par le filtre actuel —
+> ils doivent être nettoyés manuellement. Tous les charts publiés via la version
+> namespacée tombent dans le bon scope.
 
 Pour les **user-owned repos** : l'API `/user/packages/...` requiert un PAT avec scope `delete:packages`.
 Fournir le PAT via `secrets.OCI_CLEANUP_TOKEN` :


### PR DESCRIPTION
## Goal

Enable a **dual-publish** mode so that PR charts can be served simultaneously from the legacy `pr-charts` orphan branch and from the GHCR OCI registry. The two publishers are independent — consumers can opt into one, the other, or both during the migration period. The current behavior is unchanged when the new flag is left at its default.

## Changes — `ci-helm.yml` (`helm-pr-charts`)

- New input `enable_oci_pr_charts` (default `false`).
- Job runs when **either** `enable_pr_charts` or `enable_oci_pr_charts` is true.
- `packages: write` permission added at job level; `ghcr.io:443` added to harden-runner defaults.
- New step `Publish to OCI registry (GHCR)` after the existing branch publish: `helm registry login ghcr.io` with `GITHUB_TOKEN`, then `helm push <pkg>.tgz oci://ghcr.io/<owner>` for each packaged chart. Owner is lowercased per OCI spec.
- The "Publish to pr-charts branch" step is now gated by `inputs.enable_pr_charts` so OCI-only consumers don't push to the branch.
- PR comment now adapts to the modes activated, listing both install paths when dual-publish is on.

## Changes — `ci-helm-cleanup.yml`

- New input `enable_oci_cleanup` (default `false`).
- Optional secret `OCI_CLEANUP_TOKEN` (PAT with `delete:packages` scope) for user-owned repos where `GITHUB_TOKEN` cannot delete user packages.
- New step `Reconcile orphan OCI package versions (GHCR)`: detects owner type (User/Organization), lists every container package, and deletes versions tagged `*-pr<N>` whose PR is closed. Best-effort — emits `::warning::` if delete is forbidden, never breaks the workflow.

## Compatibility

- Consumers that don't set the new flags get the exact same behavior as before — the orphan branch path is unchanged.
- Default values keep all OCI logic disabled.
- Reconciliation logic introduced in #54 still applies to the branch.

## Pilot plan

After merge, a follow-up PR on `trowaflo/helm-charts` will set `enable_oci_pr_charts: true` (and `enable_oci_cleanup: true` with PAT) so we can observe the dual-publish on a real chart end-to-end.

## Why we don't migrate to OCI-only yet

`helm/chart-releaser` issue [#183](https://github.com/helm/chart-releaser/issues/183) (open since May 2022, last touched Dec 2023) tracks OCI publish support for the upstream binary; the related action issue [#107](https://github.com/helm/chart-releaser-action/issues/107) is also still open. Until the official release path supports OCI natively, dual-publish is the safest migration.