### PR TITLE
feat(ci-terraform): add reusable terraform validate/plan/apply workflow

### DIFF
--- a/.github/workflows/ci-terraform.yml
+++ b/.github/workflows/ci-terraform.yml
@@ -1,0 +1,208 @@
+name: Terraform CI
+
+# Reusable workflow — Terraform validate / plan / apply
+# Usage: uses: trowaflo/github-actions/.github/workflows/ci-terraform.yml@<sha>
+#
+# Plan job runs on pull_request, apply job runs on push to apply_branch.
+# Format check + tflint are intentionally NOT here — use lint.yml with
+# enable_terraform_validate: true for those (avoid duplication).
+
+on:
+  workflow_call:
+    inputs:
+      apply_branch:
+        description: "Branch on which apply runs (push event)"
+        type: string
+        default: "main"
+      apply_environment:
+        description: "GitHub deployment environment for the apply job (empty = no environment)"
+        type: string
+        default: ""
+      comment_plan_on_pr:
+        description: "Post the terraform plan as a comment on the PR (same-repo PRs only)"
+        type: boolean
+        default: true
+      enable_apply:
+        description: "Run terraform apply on push to apply_branch"
+        type: boolean
+        default: true
+      enable_harden_runner:
+        description: "Runtime security via StepSecurity harden-runner"
+        type: boolean
+        default: true
+      enable_sops:
+        description: "Configure SOPS with an age key (sops_age_key secret required if true)"
+        type: boolean
+        default: false
+      harden_runner_allowed_endpoints:
+        description: "Extra endpoints to allow (merged with built-in defaults, space-separated)"
+        type: string
+        default: ""
+      harden_runner_egress_policy:
+        description: "Harden-runner egress policy: audit (observe) or block (enforce allowlist)"
+        type: string
+        default: "audit"
+      terraform_version:
+        description: "Terraform version (or version constraint)"
+        type: string
+        default: "1.12.x"
+      working_directory:
+        description: "Directory containing Terraform code"
+        type: string
+        default: "."
+    secrets:
+      sops_age_key:
+        description: "Age private key for SOPS decryption (required if enable_sops)"
+        required: false
+      tf_api_token:
+        description: "Token for the Terraform backend (HCP Terraform / Terraform Cloud)"
+        required: false
+
+permissions: {}
+
+jobs:
+  plan:
+    if: ${{ github.event_name == 'pull_request' }}
+    name: Plan
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    defaults:
+      run:
+        working-directory: ${{ inputs.working_directory }}
+    env:
+      # Built-in harden-runner allowed endpoints:
+      #   agent.api.stepsecurity.io:443 — harden-runner agent
+      #   api.github.com:443 — GitHub API (actions runtime, github-script PR comment)
+      #   app.terraform.io:443 — Terraform Cloud / HCP Terraform backend
+      #   checkpoint-api.hashicorp.com:443 — Terraform CLI version check
+      #   github.com:443 — git clone, actions checkout, sops release
+      #   objects.githubusercontent.com:443 — release downloads
+      #   registry.terraform.io:443 — Terraform provider downloads
+      #   release-assets.githubusercontent.com:443 — Action releases
+      #   releases.hashicorp.com:443 — Terraform binary
+      _HARDEN_DEFAULTS: >-
+        agent.api.stepsecurity.io:443
+        api.github.com:443
+        app.terraform.io:443
+        checkpoint-api.hashicorp.com:443
+        github.com:443
+        objects.githubusercontent.com:443
+        registry.terraform.io:443
+        release-assets.githubusercontent.com:443
+        releases.hashicorp.com:443
+    steps:
+      - name: Harden Runner
+        if: ${{ inputs.enable_harden_runner }}
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        with:
+          egress-policy: ${{ inputs.harden_runner_egress_policy }}
+          allowed-endpoints: ${{ env._HARDEN_DEFAULTS }} ${{ inputs.harden_runner_allowed_endpoints }}
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Setup SOPS
+        if: ${{ inputs.enable_sops }}
+        uses: nhedger/setup-sops@358bac533e4e92f9ce9f9da563d6265929c88cda # v2.0.6
+      - name: Configure age key
+        if: ${{ inputs.enable_sops }}
+        working-directory: ${{ github.workspace }}
+        env:
+          AGE_KEY: ${{ secrets.sops_age_key }}
+        run: |
+          mkdir -p ~/.config/sops/age
+          printf '%s' "$AGE_KEY" > ~/.config/sops/age/keys.txt
+          chmod 600 ~/.config/sops/age/keys.txt
+      - uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v4.0.0
+        with:
+          terraform_version: ${{ inputs.terraform_version }}
+          cli_config_credentials_token: ${{ secrets.tf_api_token }}
+      - name: Terraform init
+        run: terraform init -input=false
+      - name: Terraform validate
+        run: terraform validate
+      - name: Terraform plan
+        id: plan
+        env:
+          SOPS_AGE_KEY_FILE: /home/runner/.config/sops/age/keys.txt
+        run: |
+          set +e
+          terraform plan -no-color -input=false -out=tfplan 2>&1 | tee plan.txt
+          exit_code=${PIPESTATUS[0]}
+          echo "exit_code=$exit_code" >> "$GITHUB_OUTPUT"
+          exit "$exit_code"
+      - name: Comment plan on PR
+        if: ${{ always() && inputs.comment_plan_on_pr && github.event.pull_request.head.repo.full_name == github.repository }}
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v8.0.0
+        env:
+          PLAN_EXIT_CODE: ${{ steps.plan.outputs.exit_code }}
+          WORKING_DIR: ${{ inputs.working_directory }}
+        with:
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+            const planPath = path.join(process.env.WORKING_DIR, 'plan.txt');
+            let plan = fs.readFileSync(planPath, 'utf8');
+            if (plan.length > 60000) {
+              plan = plan.slice(0, 60000) + '\n\n... (truncated)';
+            }
+            const exitCode = process.env.PLAN_EXIT_CODE;
+            const status = exitCode === '0' ? '✅' : '❌';
+            const body = `### Terraform Plan ${status}\n\n\`\`\`hcl\n${plan}\n\`\`\``;
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body
+            });
+
+  apply:
+    if: ${{ inputs.enable_apply && github.event_name == 'push' && github.ref == format('refs/heads/{0}', inputs.apply_branch) }}
+    name: Apply
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.apply_environment }}
+    permissions:
+      contents: read
+    defaults:
+      run:
+        working-directory: ${{ inputs.working_directory }}
+    env:
+      _HARDEN_DEFAULTS: >-
+        agent.api.stepsecurity.io:443
+        api.github.com:443
+        app.terraform.io:443
+        checkpoint-api.hashicorp.com:443
+        github.com:443
+        objects.githubusercontent.com:443
+        registry.terraform.io:443
+        release-assets.githubusercontent.com:443
+        releases.hashicorp.com:443
+    steps:
+      - name: Harden Runner
+        if: ${{ inputs.enable_harden_runner }}
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        with:
+          egress-policy: ${{ inputs.harden_runner_egress_policy }}
+          allowed-endpoints: ${{ env._HARDEN_DEFAULTS }} ${{ inputs.harden_runner_allowed_endpoints }}
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Setup SOPS
+        if: ${{ inputs.enable_sops }}
+        uses: nhedger/setup-sops@358bac533e4e92f9ce9f9da563d6265929c88cda # v2.0.6
+      - name: Configure age key
+        if: ${{ inputs.enable_sops }}
+        working-directory: ${{ github.workspace }}
+        env:
+          AGE_KEY: ${{ secrets.sops_age_key }}
+        run: |
+          mkdir -p ~/.config/sops/age
+          printf '%s' "$AGE_KEY" > ~/.config/sops/age/keys.txt
+          chmod 600 ~/.config/sops/age/keys.txt
+      - uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v4.0.0
+        with:
+          terraform_version: ${{ inputs.terraform_version }}
+          cli_config_credentials_token: ${{ secrets.tf_api_token }}
+      - name: Terraform init
+        run: terraform init -input=false
+      - name: Terraform apply
+        env:
+          SOPS_AGE_KEY_FILE: /home/runner/.config/sops/age/keys.txt
+        run: terraform apply -auto-approve -input=false

--- a/.github/workflows/test-ci-terraform.yml
+++ b/.github/workflows/test-ci-terraform.yml
@@ -1,0 +1,27 @@
+name: Test Terraform Workflow
+
+# Validates ci-terraform.yml using the test fixture in tests/terraform/.
+# Runs `terraform init/validate/plan` against a backendless config.
+#
+# Triggered:
+#   - workflow_dispatch (manual)
+#   - pull_request (every PR)
+
+on:
+  workflow_dispatch:
+  pull_request:
+
+permissions: {}
+
+jobs:
+  terraform:
+    name: Test ci-terraform.yml (plan)
+    uses: ./.github/workflows/ci-terraform.yml
+    permissions:
+      contents: read
+      pull-requests: write
+    with:
+      working_directory: tests/terraform
+      enable_apply: false
+      comment_plan_on_pr: false
+      harden_runner_egress_policy: block

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ All external `uses:` references are pinned to full commit SHAs. Renovate manages
 | [`release-helm.yml`](.github/workflows/release-helm.yml) | — (all opt-in) | [docs/helm.md](docs/helm.md) |
 | [`ci-helm-cleanup.yml`](.github/workflows/ci-helm-cleanup.yml) | — (all opt-in) | [docs/helm.md](docs/helm.md) |
 | [`ci-docker.yml`](.github/workflows/ci-docker.yml) | — (all opt-in) | [docs/ci-docker.md](docs/ci-docker.md) |
+| [`ci-terraform.yml`](.github/workflows/ci-terraform.yml) | apply on push | [docs/ci-terraform.md](docs/ci-terraform.md) |
 | [`release.yml`](.github/workflows/release.yml) | — (all opt-in) | [docs/release.md](docs/release.md) |
 | [`claude-code.yml`](.github/workflows/claude-code.yml) | — (all opt-in) | [docs/claude-code.md](docs/claude-code.md) |
 

--- a/docs/ci-terraform.md
+++ b/docs/ci-terraform.md
@@ -1,0 +1,129 @@
+# ci-terraform.yml
+
+Workflow Terraform réutilisable : `terraform validate / plan / apply`.
+
+> **Note** : `terraform fmt` et `tflint` sont **volontairement absents**. Utilise [`lint.yml`](lint.md) avec `enable_terraform_validate: true` pour ces vérifications (pas de duplication).
+
+## Usage
+
+### Cas standard (HCP Terraform + SOPS)
+
+```yaml
+# .github/workflows/terraform.yml
+name: Terraform
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "terraform/**"
+      - ".github/workflows/terraform.yml"
+  push:
+    branches: [main]
+    paths:
+      - "terraform/**"
+      - ".github/workflows/terraform.yml"
+
+permissions: {}
+
+jobs:
+  terraform:
+    uses: trowaflo/github-actions/.github/workflows/ci-terraform.yml@<sha> # vX.Y.Z
+    permissions:
+      contents: read
+      pull-requests: write
+    with:
+      working_directory: terraform
+      terraform_version: 1.12.x
+      enable_sops: true
+      apply_environment: production
+    secrets:
+      tf_api_token: ${{ secrets.TF_API_TOKEN }}
+      sops_age_key: ${{ secrets.SOPS_AGE_KEY }}
+```
+
+### Cas minimal (pas de SOPS, backend local ou autre)
+
+```yaml
+jobs:
+  terraform:
+    uses: trowaflo/github-actions/.github/workflows/ci-terraform.yml@<sha>
+    permissions:
+      contents: read
+      pull-requests: write
+    with:
+      working_directory: terraform
+```
+
+## Inputs
+
+| Input | Type | Default | Description |
+| --- | --- | --- | --- |
+| `apply_branch` | string | `"main"` | Branche sur laquelle l'apply tourne (event push) |
+| `apply_environment` | string | `""` | GitHub Deployment Environment pour le job apply (vide = aucun) |
+| `comment_plan_on_pr` | boolean | `true` | Poste le plan en commentaire sur la PR (PRs same-repo uniquement) |
+| `enable_apply` | boolean | `true` | Lance `terraform apply` sur push de `apply_branch` |
+| `enable_harden_runner` | boolean | `true` | Sécurité runtime via StepSecurity harden-runner |
+| `enable_sops` | boolean | `false` | Configure SOPS avec une age key (secret `sops_age_key` requis si `true`) |
+| `harden_runner_allowed_endpoints` | string | `""` | Endpoints supplémentaires (mergés avec les défauts, séparés par espaces) |
+| `harden_runner_egress_policy` | string | `"audit"` | Politique egress : `audit` (observe) ou `block` (enforce) |
+| `terraform_version` | string | `"1.12.x"` | Version Terraform (ou contrainte) |
+| `working_directory` | string | `"."` | Dossier contenant le code Terraform |
+
+## Secrets
+
+| Secret | Required | Description |
+| --- | --- | --- |
+| `tf_api_token` | non | Token pour le backend Terraform (HCP TF / Terraform Cloud) |
+| `sops_age_key` | non* | Clé privée age pour décryptage SOPS (*requis si `enable_sops: true`) |
+
+## Permissions requises
+
+| Permission | Jobs qui l'utilisent |
+| --- | --- |
+| `contents: read` | `plan`, `apply` (checkout) |
+| `pull-requests: write` | `plan` (commentaire du plan sur la PR) |
+
+## Comportement
+
+### Job `plan` — sur `pull_request`
+
+1. (optionnel) Harden Runner egress allowlist
+2. (optionnel) Setup SOPS + age key
+3. `terraform init`
+4. `terraform validate`
+5. `terraform plan -no-color -out=tfplan`
+6. (optionnel, same-repo PR) Commente le plan sur la PR via `actions/github-script`
+
+Le plan est tronqué à 60 000 caractères pour rester sous la limite GitHub. Le commentaire n'est posté que pour les PRs du même repo (pas les forks) afin d'éviter les fuites de plan vers des contributeurs externes.
+
+### Job `apply` — sur `push` de `apply_branch`
+
+1. (optionnel) Harden Runner
+2. (optionnel) Setup SOPS
+3. `terraform init`
+4. `terraform apply -auto-approve`
+
+L'`apply_environment` permet de gating l'apply derrière un Deployment Environment GitHub (manual approval, secrets scoped, etc.).
+
+## Endpoints harden-runner par défaut
+
+```text
+agent.api.stepsecurity.io:443      — harden-runner agent
+api.github.com:443                 — GitHub API (actions runtime, github-script)
+app.terraform.io:443               — Terraform Cloud / HCP TF backend
+checkpoint-api.hashicorp.com:443   — Terraform CLI version check
+github.com:443                     — git clone, sops release
+objects.githubusercontent.com:443  — release downloads
+registry.terraform.io:443          — Terraform provider downloads
+release-assets.githubusercontent.com:443 — Action releases
+releases.hashicorp.com:443         — Terraform binary
+```
+
+Pour des providers ou registries privés, étendre via `harden_runner_allowed_endpoints`.
+
+## Notes
+
+- **Pas de fmt/tflint** : utilise `lint.yml` avec `enable_terraform_validate: true` en parallèle.
+- **Pas de scan IaC** : utilise `security.yml` avec `enable_kics: true` (défaut) et/ou `enable_checkov: true` + `checkov_framework: "terraform"`.
+- **Plan exit code** : le step `Terraform plan` propage l'exit code natif de Terraform (0 = no diff, 1 = error, 2 = diff present si `-detailed-exitcode`). Le commentaire PR est posté même en cas d'échec (`if: always()`).


### PR DESCRIPTION
## Summary

- New reusable workflow `ci-terraform.yml` covering `terraform init`, `validate`, `plan` (with PR comment) and `apply` (on push to `apply_branch`).
- Test workflow `test-ci-terraform.yml` runs the new workflow against the existing `tests/terraform/` fixture (backendless, plan-only).
- Docs at `docs/ci-terraform.md` + `README.md` table updated.

`fmt` and `tflint` are intentionally **not** included — `lint.yml` with `enable_terraform_validate: true` already covers those (no duplication).

## Design

- `enable_sops` toggle + `sops_age_key` secret → optional SOPS+age decryption for `terraform plan/apply`.
- `apply_environment` input → wires the apply job to a GitHub Deployment Environment for manual approval.
- `comment_plan_on_pr` (default `true`) gated on `head.repo.full_name == github.repository` to avoid leaking plans to fork PRs.
- Plan output truncated at 60 000 chars (GitHub comment limit).
- Built-in harden-runner allowed endpoints cover the HCP TF + Hashicorp release path; extra endpoints can be merged via `harden_runner_allowed_endpoints`.
- `tf_api_token` is optional (works without HCP TF backend).

## Test plan

- [ ] `test-ci-terraform.yml` runs and the plan job succeeds against `tests/terraform/main.tf`.
- [ ] `actionlint` + `yamllint` + `markdownlint` pass on the new files (verified locally).
- [ ] Self-CI (`ci.yml`) green: security/lint/sha-check/lint-renovate.
- [ ] Once merged + tagged, consume from `terraform-authentik` (separate PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)