### PR TITLE
feat(release-helm): add enable_oci_release toggle for GHCR dual-publish on main

### DIFF
--- a/.github/workflows/release-helm.yml
+++ b/.github/workflows/release-helm.yml
@@ -56,7 +56,7 @@ jobs:
       #   agent.api.stepsecurity.io:443 — harden-runner agent
       #   api.github.com:443 — GitHub API (chart-releaser)
       #   get.helm.sh:443 — Helm binary (azure/setup-helm)
-      #   ghcr.io:443 — OCI registry (only when enable_oci_release is true)
+      #   ghcr.io:443 — OCI chart registry (used when enable_oci_release is true)
       #   github.com:443 — git clone, actions checkout
       #   objects.githubusercontent.com:443 — GitHub release assets (yq binary)
       #   rekor.sigstore.dev:443 — Sigstore transparency log (cosign verification)

--- a/.github/workflows/release-helm.yml
+++ b/.github/workflows/release-helm.yml
@@ -16,6 +16,14 @@ on:
         description: "Release charts via chart-releaser (multi-dir support via release_charts_dirs)"
         type: boolean
         default: false
+      enable_oci_release:
+        description: >-
+          Additionally publish released charts to GHCR OCI registry
+          (oci://ghcr.io/<owner>/<repo>/<chart>:<version>). The repo namespace prevents
+          collisions across repos under the same owner. Mirrors the pattern of
+          enable_oci_pr_charts in ci-helm.yml.
+        type: boolean
+        default: false
       harden_runner_allowed_endpoints:
         description: >-
           Extra endpoints to allow (merged with built-in defaults, space-separated).
@@ -42,11 +50,13 @@ jobs:
     permissions:
       contents: write
       pages: write
+      packages: write
     env:
       # Built-in harden-runner allowed endpoints:
       #   agent.api.stepsecurity.io:443 — harden-runner agent
       #   api.github.com:443 — GitHub API (chart-releaser)
       #   get.helm.sh:443 — Helm binary (azure/setup-helm)
+      #   ghcr.io:443 — OCI registry (only when enable_oci_release is true)
       #   github.com:443 — git clone, actions checkout
       #   objects.githubusercontent.com:443 — GitHub release assets (yq binary)
       #   rekor.sigstore.dev:443 — Sigstore transparency log (cosign verification)
@@ -57,6 +67,7 @@ jobs:
         agent.api.stepsecurity.io:443
         api.github.com:443
         get.helm.sh:443
+        ghcr.io:443
         github.com:443
         objects.githubusercontent.com:443
         rekor.sigstore.dev:443
@@ -135,6 +146,7 @@ jobs:
             if [ -f "$chart/Chart.yaml" ]; then helm dependency build "$chart"; fi
           done
       - name: Release first directory
+        id: release_first
         if: ${{ github.event_name != 'pull_request' }}
         uses: helm/chart-releaser-action@cae68fefc6b5f367a0275617c9f83181ba54714f # v1.7.0
         with:
@@ -144,6 +156,31 @@ jobs:
           CR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CR_SKIP_EXISTING: true
           CR_GENERATE_RELEASE_NOTES: true
+      - name: Publish first directory to OCI registry (GHCR)
+        if: ${{ inputs.enable_oci_release && github.event_name != 'pull_request' && steps.release_first.outcome == 'success' }}
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          ACTOR: ${{ github.actor }}
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          pkg_dir=".cr-release-packages"
+          if [ ! -d "$pkg_dir" ] || [ -z "$(ls -A "$pkg_dir" 2>/dev/null)" ]; then
+            echo "No release packages produced by chart-releaser — nothing to push to OCI."
+            exit 0
+          fi
+          owner_lc=$(echo "$OWNER" | tr '[:upper:]' '[:lower:]')
+          repo_name_lc=$(echo "${REPO#*/}" | tr '[:upper:]' '[:lower:]')
+          target="oci://ghcr.io/${owner_lc}/${repo_name_lc}"
+          echo "$GITHUB_TOKEN" | helm registry login ghcr.io --username "$ACTOR" --password-stdin
+          trap 'helm registry logout ghcr.io >/dev/null 2>&1 || true' EXIT
+          for tgz in "$pkg_dir"/*.tgz; do
+            [ -f "$tgz" ] || continue
+            echo "Pushing $(basename "$tgz") → ${target}"
+            helm push "$tgz" "${target}"
+          done
+          rm -rf "$pkg_dir"
       - name: Add self as Helm repository
         if: ${{ steps.dirs.outputs.second != '' }}
         env:
@@ -161,6 +198,7 @@ jobs:
             if [ -f "$chart/Chart.yaml" ]; then helm dependency build "$chart"; fi
           done
       - name: Release second directory
+        id: release_second
         if: ${{ steps.dirs.outputs.second != '' && github.event_name != 'pull_request' }}
         uses: helm/chart-releaser-action@cae68fefc6b5f367a0275617c9f83181ba54714f # v1.7.0
         with:
@@ -170,3 +208,28 @@ jobs:
           CR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CR_SKIP_EXISTING: true
           CR_GENERATE_RELEASE_NOTES: true
+      - name: Publish second directory to OCI registry (GHCR)
+        if: ${{ inputs.enable_oci_release && steps.dirs.outputs.second != '' && github.event_name != 'pull_request' && steps.release_second.outcome == 'success' }}
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          ACTOR: ${{ github.actor }}
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          pkg_dir=".cr-release-packages"
+          if [ ! -d "$pkg_dir" ] || [ -z "$(ls -A "$pkg_dir" 2>/dev/null)" ]; then
+            echo "No release packages produced by chart-releaser — nothing to push to OCI."
+            exit 0
+          fi
+          owner_lc=$(echo "$OWNER" | tr '[:upper:]' '[:lower:]')
+          repo_name_lc=$(echo "${REPO#*/}" | tr '[:upper:]' '[:lower:]')
+          target="oci://ghcr.io/${owner_lc}/${repo_name_lc}"
+          echo "$GITHUB_TOKEN" | helm registry login ghcr.io --username "$ACTOR" --password-stdin
+          trap 'helm registry logout ghcr.io >/dev/null 2>&1 || true' EXIT
+          for tgz in "$pkg_dir"/*.tgz; do
+            [ -f "$tgz" ] || continue
+            echo "Pushing $(basename "$tgz") → ${target}"
+            helm push "$tgz" "${target}"
+          done
+          rm -rf "$pkg_dir"

--- a/.github/workflows/test-helm.yml
+++ b/.github/workflows/test-helm.yml
@@ -39,8 +39,10 @@ jobs:
     permissions:
       contents: write
       pages: write
+      packages: write
     with:
       enable_release: true
+      enable_oci_release: true
       harden_runner_egress_policy: block
 
   helm-pr-cleanup:

--- a/docs/helm.md
+++ b/docs/helm.md
@@ -94,7 +94,14 @@ jobs:
 | `harden_runner_egress_policy` | string | `"audit"` | Egress policy: `audit` or `block` |
 | `harden_runner_allowed_endpoints` | string | (built-in) | Extra endpoints merged with defaults |
 | `enable_release` | boolean | `false` | Release via chart-releaser |
+| `enable_oci_release` | boolean | `false` | Publie aussi les charts releasés sur GHCR OCI (`oci://ghcr.io/<owner>/<repo>/<chart>:<version>`). Mirror du pattern `enable_oci_pr_charts` côté `ci-helm.yml`. |
 | `release_charts_dirs` | string | `""` | Répertoires de charts à releaser (max 2, space-separated). Defaults to `charts` |
+
+### Permissions requises pour `enable_oci_release`
+
+Le caller doit accorder `packages: write` au job pour que `helm push` puisse écrire
+sur GHCR. Le `GITHUB_TOKEN` standard est suffisant — pas de PAT nécessaire (les
+release charts sont immuables, donc pas de delete).
 
 ---
 


### PR DESCRIPTION
## Summary

Adds an `enable_oci_release` toggle to `release-helm.yml`, mirroring the `enable_oci_pr_charts` pattern introduced in `ci-helm.yml` (PR #55, v2.0.0). When enabled, every chart released by `chart-releaser-action` is also pushed to `oci://ghcr.io/<owner>/<repo>/<chart>:<version>`.

Why: the v2.0.0 OCI dual-publish only covers PR test charts. Production releases on `main` still go to GitHub Pages only, so consumers can't pull versioned releases from GHCR.

## Changes

- **`release-helm.yml`** (+63):
  - New input `enable_oci_release: bool, default false`
  - `permissions: packages: write` (needed for `helm push`)
  - Built-in endpoint `ghcr.io:443` allowed (active only when toggle on)
  - Two new steps `Publish first/second directory to OCI registry (GHCR)`, gated on the corresponding `chart-releaser` outcome being success and on `inputs.enable_oci_release`
- **`test-helm.yml`** (+2): activate `enable_oci_release: true` in the test job and grant `packages: write`
- **`docs/helm.md`** (+7): document the new input + required permissions

## Design notes

- **Why no cleanup workflow change** — release charts are immutable. Unlike PR test charts (which carry a `-pr<N>` suffix and are deleted at PR close), release versions are tagged `<version>` and are part of the public release history. No GHCR cleanup needed.
- **Tag scheme** — `oci://ghcr.io/<owner>/<repo>/<chart>:<version>`, identical to `enable_oci_pr_charts` minus the `-pr<N>` suffix. The repo namespace prevents collisions across repos under the same owner.
- **Conditional logic** — push runs only if the matching `chart-releaser-action` step succeeded **and** `.cr-release-packages/` is non-empty. If chart-releaser had nothing to publish (no `Chart.yaml` version bump), the OCI step exits 0 cleanly.
- **Auth** — standard `GITHUB_TOKEN` via `helm registry login`, `--username github.actor`. No PAT (no delete needed). Same pattern as `enable_oci_pr_charts`.
- **Cleanup of `.cr-release-packages/`** — explicit `rm -rf` between the two release directories so that the second push isn't polluted by the first dir's tarballs.

## Test plan

- [x] YAML parse (`yaml.safe_load`) on both modified workflows
- [x] Self-test in `test-helm.yml` updated to enable the toggle
- [ ] CI green on this PR
- [ ] Once merged + tagged, validate via downstream `trowaflo/helm-charts` PR by bumping `release-helm.yml` and confirming `helm pull oci://ghcr.io/trowaflo/helm-charts/<chart>:<version>` works after a release on `main`

## Backward compatibility

- Default `enable_oci_release: false` → no behavior change for existing callers.
- Adding `packages: write` to the job's permissions does not require existing callers to change anything (it's only used when the new toggle is on, and the chart-releaser job already requires elevated perms).
