### PR TITLE
feat(security)!: default harden-runner egress policy to block

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -44,7 +44,7 @@ on:
       harden_runner_egress_policy:
         description: "Harden-runner egress policy: audit (observe) or block (enforce allowlist)"
         type: string
-        default: "audit"
+        default: "block"
       trivy_severity:
         description: "Trivy severity levels: UNKNOWN, LOW, MEDIUM, HIGH, CRITICAL"
         type: string

--- a/docs/security.md
+++ b/docs/security.md
@@ -22,10 +22,10 @@ jobs:
 | Input | Type | Default | Description |
 | --- | --- | --- | --- |
 | `enable_harden_runner` | boolean | `true` | Runtime security via StepSecurity harden-runner |
-| `harden_runner_egress_policy` | string | `"audit"` | Egress policy: `audit` (observe) or `block` (enforce allowlist) |
+| `harden_runner_egress_policy` | string | `"block"` | Egress policy: `audit` (observe) or `block` (enforce allowlist) |
 | `harden_runner_allowed_endpoints` | string | `(built-in)` | Allowed endpoints when block (space-separated) — extra endpoints merged with defaults |
 | `enable_gitleaks` | boolean | `true` | Secret scanning avec gitleaks |
-| `enable_kics` | boolean | `true` | Scan IaC avec KICS (⚠ TeamPCP 2026-03-23 — SHA pinné pré-incident) |
+| `enable_kics` | boolean | `true` | Scan IaC avec KICS (SHA `05aa5eb` = v2.1.20, release officielle vérifiée post-TeamPCP) |
 | `enable_dependency_review` | boolean | `false` | Revue CVE sur PR — **nécessite event `pull_request`** |
 | `enable_checkov` | boolean | `false` | Scan IaC misconfigurations avec Checkov |
 | `enable_trivy` | boolean | `false` | Scan IaC/filesystem avec Trivy |
@@ -74,6 +74,6 @@ with:
 
 ### harden-runner
 
-[StepSecurity harden-runner](https://github.com/step-security/harden-runner) sécurise le réseau de chaque job. Par défaut, la politique egress est `audit` — le trafic sortant est observé sans blocage. Passer à `block` une fois les endpoints connus.
+[StepSecurity harden-runner](https://github.com/step-security/harden-runner) sécurise le réseau de chaque job. Depuis le 2026-08-14, la politique egress par défaut est `block` : tout trafic sortant hors allowlist est coupé. C'est la parade au vecteur TeamPCP, dont le canal d'exfiltration primaire était un POST vers un domaine tiers. Repasser à `audit` sur un repo dont les endpoints ne sont pas encore connus, jamais comme réglage durable.
 
 Le workflow inclut une liste d'endpoints par défaut couvrant ses dépendances internes. Le consumer peut ajouter des endpoints via `harden_runner_allowed_endpoints` — ils sont **fusionnés** avec la liste par défaut.


### PR DESCRIPTION
## Pourquoi

L'attaque supply-chain TeamPCP sur `checkmarx/kics-github-action` (2026-03-23) exfiltrait les secrets du runner par un POST HTTPS vers `checkmarx.zone`. Treize repos de ce compte ont exécuté le payload ce jour-là, via des PR Renovate qui avaient tiré le SHA malveillant `b974e53`.

Épingler l'action par SHA ne protège pas de ça. L'action construit son Dockerfile au runtime depuis `FROM checkmarx/kics:v2.1.20`, un tag mutable : ce qui s'exécute n'est jamais figé par le pin. Le tag Docker Hub a d'ailleurs été repointé sur un digest malveillant le 2026-04-22.

Faire respecter l'allowlist d'egress est la seule couche qu'on contrôle de bout en bout. Elle coupe le canal d'exfiltration primaire quelle que soit l'image tirée.

## Preuve que ça ne casse rien

`ci.yml` appelle déjà `security.yml` avec `harden_runner_egress_policy: block`. Les jobs `IaC Scan (KICS)`, `IaC Scan (Checkov)` et `IaC Scan (Trivy)` sont passés verts le 2026-04-09 ([run 24213273365](https://github.com/trowaflo/github-actions/actions/runs/24213273365)). L'allowlist intégrée suffit.

## Ce que ça change

- `harden_runner_egress_policy` passe de `"audit"` à `"block"` par défaut.
- Un consumer dont un job sort vers un endpoint hors allowlist échouera, jusqu'à ajout via `harden_runner_allowed_endpoints`.
- Repasser explicitement à `"audit"` restaure le comportement précédent.

## Hors périmètre, signalé

- Les huit autres workflows réutilisables (`lint.yml`, `ci-docker.yml`, `ci-ha.yml`, `ci-helm.yml`, `ci-python.yml`, `release.yml`, `release-helm.yml`, `lint-renovate.yml`) restent en `audit`. Seuls `lint.yml` et `lint-renovate.yml` sont déjà prouvés verts en `block` par la self-CI.
- Le pin KICS reste `05aa5eb` (v2.1.20), dernière release officielle publiée par Checkmarx, vérifiée le 2026-08-14.
- `CLAUDE.md` porte encore la formulation « pinned to a pre-incident commit », à corriger dans une passe séparée.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018tnNzt8kSuX88cRnvNhLL8