### PR TITLE
fix(ci): complete the reusable workflow permission contracts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,11 @@ jobs:
     permissions:
       contents: read
       security-events: write
+      # Requis par les jobs shellcheck et shfmt de lint.yml, qui postent via reviewdog.
+      # Ils sont désactivés par défaut et ne tournent pas ici, mais GitHub valide le
+      # contrat de permissions de TOUS les jobs du workflow appelé au démarrage,
+      # avant d'évaluer le moindre `if:`. Sans cette ligne, startup_failure.
+      pull-requests: write
     with:
       enable_harden_runner: true
       harden_runner_egress_policy: block

--- a/.github/workflows/test-helm.yml
+++ b/.github/workflows/test-helm.yml
@@ -52,6 +52,12 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      # Requis par le job helm-pr-cleanup de ci-helm-cleanup.yml, qui le déclare.
+      # Le contrat de permissions d'un workflow appelé est validé au démarrage,
+      # indépendamment de enable_oci_cleanup et de tout `if:`. Sans cette ligne,
+      # startup_failure. Aucun DELETE GHCR n'est émis pour autant, voir la note
+      # ci-dessous : c'est enable_oci_cleanup qui commande cette étape.
+      packages: write
     # Note: enable_oci_cleanup is intentionally NOT enabled here.
     # Even though the cleanup step filters by the "<repo>/" GHCR namespace prefix
     # (so it would only target packages produced by this repo's helm-pr-charts),


### PR DESCRIPTION
## Le symptôme

Deux workflows en `startup_failure` permanent. Zéro job créé, aucune ligne fautive exposée, juste la bannière générique « This run likely failed because of a workflow file issue. »

- `CI` depuis au moins le 2026-07-24. Dernier vert : [24213273365](https://github.com/trowaflo/github-actions/actions/runs/24213273365), le 2026-04-09, depuis une branche qui portait un `lint.yml` différent.
- `Test Helm Workflows`, même signature.

## La cause, deux fois la même

Un job appelant un reusable workflow doit couvrir **tous** les jobs du workflow appelé. Deux contrats étaient courts.

| Appelant | Job | Appelé | Scope manquant |
| --- | --- | --- | --- |
| `ci.yml` | `lint` | `lint.yml` | `pull-requests: write` |
| `test-helm.yml` | `helm-pr-cleanup` | `ci-helm-cleanup.yml` | `packages: write` |

Le premier vient des jobs `shellcheck` et `shfmt`, qui postent via reviewdog. Introduit par `fec84c5`, qui a ajouté les deux linters sans élargir l'appelant.

## Le point non-évident

`enable_shellcheck` et `enable_shfmt` valent `false` par défaut et ne sont pas passés. **Ces deux jobs ne tournent jamais.** Idem pour `enable_oci_cleanup` côté helm, délibérément laissé off.

GitHub valide quand même le contrat de permissions de chaque job du workflow appelé **au démarrage, avant d'évaluer le moindre `if:`**. Des jobs qui ne s'exécutent pas tuaient donc tout le workflow. C'est ce qui rend le diagnostic contre-intuitif : chercher le job en échec ne mène nulle part, puisqu'aucun job n'est créé.

Élargir le scope ne fait rien exécuter de plus. Côté helm en particulier, aucun `DELETE` GHCR n'est émis : ces appels restent derrière `enable_oci_cleanup`, comme l'explique la note déjà présente dans le fichier.

## Vérification

Audit de **tous** les appelants `uses: ./` du repo, pas seulement `ci.yml`. Pour chaque job, comparaison entre les permissions accordées et l'union de celles exigées par les jobs appelés.

Avant : 2 contrats incomplets.
Après : `contrats de permissions incomplets: 0`.

Et surtout, en réel : `CI` est repassée **verte** sur cette branche, première fois depuis le 2026-04-09. `Test Helm Workflows` sort aussi du `startup_failure`.

## Hors périmètre, signalé

`Test Docker Workflow`, `Test HA Workflow` et `Test Python Workflow` échouent toujours, mais pour d'autres raisons, pas en `startup_failure`. `Test Python` casse sur `codecov/codecov-action`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018tnNzt8kSuX88cRnvNhLL8
